### PR TITLE
fix: indentations inside yaml examples for several types

### DIFF
--- a/Documentation/IntegratorManual/YamlReference/Link/Index.rst
+++ b/Documentation/IntegratorManual/YamlReference/Link/Index.rst
@@ -77,8 +77,8 @@ Advanced / use case
           - file
         required: true
         valuePicker:
-        items:
-          [
-            ['https://www.typo3.org', TYPO3 CMS],
-            ['https://www.typo3.com', TYPO3 GmbH],
-          ]
+          items:
+            [
+              ['https://www.typo3.org', TYPO3 CMS],
+              ['https://www.typo3.com', TYPO3 GmbH],
+            ]

--- a/Documentation/IntegratorManual/YamlReference/Number/Index.rst
+++ b/Documentation/IntegratorManual/YamlReference/Number/Index.rst
@@ -117,16 +117,16 @@ Advanced / use case
         default: 10
         size: 20
         range:
-        lower: 10
-        upper: 999
+          lower: 10
+          upper: 999
         slider:
-        range:
-          step: 1
-          width: 100
+          range:
+            step: 1
+            width: 100
         valuePicker:
-        items:
-          [
-            [ '100', 100 ],
-            [ '250', 250 ],
-            [ '500', 500 ],
-          ]
+          items:
+            [
+              [ '100', 100 ],
+              [ '250', 250 ],
+              [ '500', 500 ],
+            ]


### PR DESCRIPTION
This fixes some wrong indentations inside the documentation.
fixes #5
fixes #6 