### PR TITLE
[BUGFIX] Prevent TypeError for transformSelectSingleRelation

### DIFF
--- a/Classes/DataProcessing/ContentBlockDataResolver.php
+++ b/Classes/DataProcessing/ContentBlockDataResolver.php
@@ -91,7 +91,7 @@ final class ContentBlockDataResolver
         return $processedField;
     }
 
-    private function transformSelectSingleRelation(array $processedField, TcaFieldDefinition $tcaFieldDefinition, string $table, int $depth): ContentBlockData
+    private function transformSelectSingleRelation(array $processedField, TcaFieldDefinition $tcaFieldDefinition, string $table, int $depth): array|ContentBlockData
     {
         $foreignTable = $tcaFieldDefinition->getTca()['config']['foreign_table'] ?? $GLOBALS['TCA'][$table]['columns'][$tcaFieldDefinition->getUniqueIdentifier()]['config']['foreign_table'] ?? '';
         if ($this->tableDefinitionCollection->hasTable($foreignTable)) {


### PR DESCRIPTION
The method might return an simple array, in case the referenced table is not defined as content block itself.
Therefore the return type needs to state that an array is possible as well.

Fixes: #69