### PR TITLE
[TASK] Improve test command and add hint for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ composer install
 Then run unit or functional tests by executing:
 
 ```
-Build/Scripts/runTests.sh -s unit
-Build/Scripts/runTests.sh -s functional
+Build/Scripts/runTests.sh -p 8.2 -s unit
+Build/Scripts/runTests.sh -p 8.2 -s functional
 ```
+
+### Hint
+
+Be sure to exclude the `.Build` directory from indexing in your IDE (e.g. PhpStorm) before starting the tests.
 
 ## Feedback
 


### PR DESCRIPTION
Currently the default PHP version of the testing framework is PHP 8.1 but the package requires PHP 8.2.