### PR TITLE
41 - adds image manipulation to type file

### DIFF
--- a/Classes/FieldConfiguration/FileFieldConfiguration.php
+++ b/Classes/FieldConfiguration/FileFieldConfiguration.php
@@ -36,6 +36,7 @@ final class FileFieldConfiguration implements FieldConfigurationInterface
     private int $minitems = 0;
     private int $maxitems = 0;
     private bool $extendedPalette = true;
+    private array $cropVariants = [];
 
     public static function createFromArray(array $settings): FileFieldConfiguration
     {
@@ -55,6 +56,10 @@ final class FileFieldConfiguration implements FieldConfigurationInterface
         $self->minitems = (int)($settings['minitems'] ?? $self->minitems);
         $self->maxitems = (int)($settings['maxitems'] ?? $self->maxitems);
         $self->extendedPalette = (bool)($settings['extendedPalette'] ?? $self->extendedPalette);
+        $cropVariants = $settings['cropVariants'] ?? $self->cropVariants;
+        if (is_array($cropVariants) || is_string($cropVariants)) {
+            $self->cropVariants = $cropVariants;
+        }
         return $self;
     }
 
@@ -98,6 +103,14 @@ final class FileFieldConfiguration implements FieldConfigurationInterface
                 ],
             ];
         }
+        // Cropping:
+        if ($this->cropVariants !== []) {
+            $config['overrideChildTca']['columns']['crop']['config']['cropVariants'] = [];
+            foreach($this->cropVariants as $device => $options) {
+                $config['overrideChildTca']['columns']['crop']['config']['cropVariants'][$device] = $options;
+            }
+        }
+
         $tca['config'] = array_replace($tca['config'] ?? [], $config);
         return $tca;
     }

--- a/Documentation/YamlReference/FieldTypes/File/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/File/Index.rst
@@ -52,6 +52,33 @@ Settings
    prevents the record from being saved if the limit is not satisfied.
    The field can be set as required by setting `minitems` to at least 1.
 
+.. confval:: cropVariants
+
+   :Required: false
+   :Type: array
+   :Default: []
+
+   It is possible to define crop variants for this specific field and Content
+   Block. This documentation only covers the most basic configuration. Refer to
+   the :ref:`TCA documentation <columns-imageManipulation-properties-cropVariants>`
+   for a complete overview of possibilities.
+
+   Example configuration below. The aspect ratios can be defined as a float
+   value or a fraction. Only the simple division operation `a / b` is allowed.
+
+   .. code-block:: yaml
+
+    cropVariants:
+      teaser:
+        title: Teaser
+        allowedAspectRatios:
+          portrait:
+            title: Portrait
+            value: 0.75
+          landscape:
+            title: Landscape
+            value: 4 / 3
+
 For more advanced configuration refer to the :ref:`TCA documentation <t3tca:columns-file>`.
 
 Example

--- a/Tests/Unit/FieldTypes/FileFieldConfigurationTest.php
+++ b/Tests/Unit/FieldTypes/FileFieldConfigurationTest.php
@@ -49,6 +49,40 @@ final class FileFieldConfigurationTest extends UnitTestCase
                 'readOnly' => 1,
                 'minitems' => 1,
                 'maxitems' => 1,
+                'cropVariants' => [
+                    'foo' => [
+                        'allowedAspectRatios' => [
+                            'portrait' => [
+                                'title' => 'Portrait',
+                                'value' => '3 / 4',
+                            ],
+                            'landscape' => [
+                                'title' => 'Landscape',
+                                'value' => '1.333',
+                            ],
+                            'plain integer' => [
+                                'title' => 'Plain Integer',
+                                'value' => 4,
+                            ],
+                            'wrong input 1' => [
+                                'title' => 'wrong input 1',
+                                'value' => 'a',
+                            ],
+                            'wrong input 2' => [
+                                'title' => 'wrong input 2',
+                                'value' => 'a / b',
+                            ],
+                            'wrong input 3' => [
+                                'title' => 'wrong input 3',
+                                'value' => '1 /',
+                            ],
+                            'wrong input 4' => [
+                                'title' => 'wrong input 4',
+                                'value' => '/ 1',
+                            ],
+                        ],
+                    ],
+                ],
             ],
             'expectedTca' => [
                 'label' => 'foo',
@@ -73,6 +107,48 @@ final class FileFieldConfigurationTest extends UnitTestCase
                     'readOnly' => true,
                     'minitems' => 1,
                     'maxitems' => 1,
+                    'overrideChildTca' => [
+                        'columns' => [
+                            'crop' => [
+                                'config' => [
+                                    'cropVariants' => [
+                                        'foo' => [
+                                            'allowedAspectRatios' => [
+                                                'portrait' => [
+                                                    'title' => 'Portrait',
+                                                    'value' => 0.75,
+                                                ],
+                                                'landscape' => [
+                                                    'title' => 'Landscape',
+                                                    'value' => 1.333,
+                                                ],
+                                                'plain integer' => [
+                                                    'title' => 'Plain Integer',
+                                                    'value' => 4.0,
+                                                ],
+                                                'wrong input 1' => [
+                                                    'title' => 'wrong input 1',
+                                                    'value' => 0.0,
+                                                ],
+                                                'wrong input 2' => [
+                                                    'title' => 'wrong input 2',
+                                                    'value' => 0.0,
+                                                ],
+                                                'wrong input 3' => [
+                                                    'title' => 'wrong input 3',
+                                                    'value' => 1.0,
+                                                ],
+                                                'wrong input 4' => [
+                                                    'title' => 'wrong input 4',
+                                                    'value' => 0.0,
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -95,6 +171,7 @@ final class FileFieldConfigurationTest extends UnitTestCase
                 'readOnly' => 0,
                 'minitems' => 0,
                 'maxitems' => 0,
+                'cropVariants' => [],
             ],
             'expectedTca' => [
                 'config' => [


### PR DESCRIPTION
I tried to solve the issue #41 

This is still WIP.

The array is written to the TCA, but it doesn't work at the moment. I think we need a special fieldType "ImageManipulation" for this.
https://docs.typo3.org/m/typo3/reference-tca/main/en-us/ColumnsConfig/Type/ImageManipulation/Properties/CropVariants.html