### PR TITLE
[DOC] Fix label example for flexform sections

### DIFF
--- a/Documentation/YamlReference/FieldTypes/FlexForm/Section/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/FlexForm/Section/Index.rst
@@ -80,10 +80,10 @@ XLF translation keys for Sections and Containers have the following convention:
 .. code-block:: xml
 
     <body>
-        <trans-unit id="FIELD_IDENTIFIER.sections.SECTION_IDENTIFIER.label">
+        <trans-unit id="FIELD_IDENTIFIER.sections.SECTION_IDENTIFIER.title">
             <source>Label for Section</source>
         </trans-unit>
-        <trans-unit id="FIELD_IDENTIFIER.sections.SECTION_IDENTIFIER.container.CONTAINER_IDENTIFIER.label">
+        <trans-unit id="FIELD_IDENTIFIER.sections.SECTION_IDENTIFIER.container.CONTAINER_IDENTIFIER.title">
             <source>Label for Container</source>
         </trans-unit>
         <trans-unit id="FIELD_IDENTIFIER.sections.SECTION_IDENTIFIER.container.CONTAINER_IDENTIFIER.FIELD_IDENTIFIER.label">


### PR DESCRIPTION
Sections and containers use `title` instead of `label` as the last part of the label.