### PR TITLE
[DOC] Fix indentation in example for field type 'select'

### DIFF
--- a/Documentation/YamlReference/FieldTypes/Select/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Select/Index.rst
@@ -186,4 +186,4 @@ Select tree:
         foreign_table: 'pages'
         foreign_table_where: 'ORDER BY pages.uid'
         treeConfig:
-        parentField: pid
+          parentField: pid


### PR DESCRIPTION
The indentation was wrong. I got an error in the backend which is gone with the new indentation.