### PR TITLE
[FEATURE] Add first basic support for nested content elements

### DIFF
--- a/Build/content-blocks-examples/ContentBlocks/ContentElements/tabs/EditorInterface.yaml
+++ b/Build/content-blocks-examples/ContentBlocks/ContentElements/tabs/EditorInterface.yaml
@@ -6,9 +6,12 @@ fields:
     type: Collection
     labelField: title
     minitems: 1
-    fields:
-      - identifier: title
-        type: Text
-      - identifier: textarea
-        type: Textarea
-        enableRichtext: true
+    foreign_table: tt_content
+    overrideChildTca:
+      columns:
+        CType:
+          config:
+            default: example_text
+            readOnly: true
+    foreign_match_fields:
+      CType: example_text

--- a/Build/content-blocks-examples/ContentBlocks/ContentElements/tabs/EditorInterface.yaml
+++ b/Build/content-blocks-examples/ContentBlocks/ContentElements/tabs/EditorInterface.yaml
@@ -4,7 +4,6 @@ fields:
     useExistingField: true
   - identifier: tabs_item
     type: Collection
-    labelField: title
     minitems: 1
     foreign_table: tt_content
     overrideChildTca:

--- a/Build/content-blocks-examples/ContentBlocks/ContentElements/tabs/Source/Frontend.html
+++ b/Build/content-blocks-examples/ContentBlocks/ContentElements/tabs/Source/Frontend.html
@@ -11,15 +11,14 @@
     <div class="tab">
         <f:for each="{data.tabs_item}" as="item" iteration="i">
             <button class="tab-links{f:if(condition: i.isFirst, then: ' active', else: '')}" data-target="tab-{data.uid}-{item.uid}">
-                {item.title}
+                {item.header}
             </button>
         </f:for>
     </div>
     <f:for each="{data.tabs_item}" as="item" iteration="i">
         <f:variable name="style">style="display:{f:if(condition: i.isFirst, then: 'block', else: 'none')};"</f:variable>
-
         <div id="tab-{data.uid}-{item.uid}" class="tab-content" {style -> f:format.raw()}>
-            <f:format.html>{item.textarea}</f:format.html>
+            <f:cObject typoscriptObjectPath="tt_content.{item.typeName}" table="{item.tableName}" data="{item._raw}"/>
         </div>
     </f:for>
 </div>

--- a/Build/content-blocks-examples/ContentBlocks/ContentElements/text/Assets/Icon.svg
+++ b/Build/content-blocks-examples/ContentBlocks/ContentElements/text/Assets/Icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 16 16"><path fill="#FFF" d="M1 1h14v14H1V1z"/><path fill="#999" d="M1 1v14h14V1H1zm1 1h12v12H2V2z"/><path fill="#666" d="M3 3h10v2H3V3z"/><path fill="#B9B9B9" d="M3 6h10v1H3V6zm0 2h10v1H3V8zm0 2h10v1H3v-1zm0 2h10v1H3v-1z"/></svg>

--- a/Build/content-blocks-examples/ContentBlocks/ContentElements/text/EditorInterface.yaml
+++ b/Build/content-blocks-examples/ContentBlocks/ContentElements/text/EditorInterface.yaml
@@ -1,0 +1,10 @@
+name: example/text
+group: common
+prefixFields: true
+prefixType: full
+fields:
+  - identifier: header
+    useExistingField: true
+  - identifier: bodytext
+    useExistingField: true
+    enableRichtext: true

--- a/Build/content-blocks-examples/ContentBlocks/ContentElements/text/Source/Frontend.html
+++ b/Build/content-blocks-examples/ContentBlocks/ContentElements/text/Source/Frontend.html
@@ -1,0 +1,2 @@
+<h1>{data.header}</h1>
+<f:format.html>{data.bodytext}</f:format.html>

--- a/Build/content-blocks-examples/ContentBlocks/ContentElements/text/Source/Language/Labels.xlf
+++ b/Build/content-blocks-examples/ContentBlocks/ContentElements/text/Source/Language/Labels.xlf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+	<file datatype="plaintext" original="Labels.xlf" source-language="en" date="2024-01-30T18:23:22+00:00" product-name="example/text">
+		<header/>
+		<body>
+			<trans-unit id="title" resname="title">
+				<source>Text</source>
+			</trans-unit>
+			<trans-unit id="description" resname="description">
+				<source>Simple text element</source>
+			</trans-unit>
+			<trans-unit id="header.label" resname="header.label">
+				<source>Header</source>
+			</trans-unit>
+		</body>
+	</file>
+</xliff>

--- a/Classes/Backend/Layout/HideContentElementChildrenEventListener.php
+++ b/Classes/Backend/Layout/HideContentElementChildrenEventListener.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\ContentBlocks\Backend\Layout;
+
+use TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForContentEvent;
+use TYPO3\CMS\ContentBlocks\Service\TtContentParentField;
+use TYPO3\CMS\Core\Database\Connection;
+
+/**
+ * @internal
+ */
+final class HideContentElementChildrenEventListener
+{
+    public function __construct(
+        private readonly TtContentParentField $ttContentParentField
+    ) {}
+
+    public function __invoke(ModifyDatabaseQueryForContentEvent $event): void
+    {
+        $queryBuilder = $event->getQueryBuilder();
+
+        foreach ($this->ttContentParentField->getAllFieldNames() as $fieldName) {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->eq(
+                    $fieldName,
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)
+                )
+            );
+        }
+
+        $event->setQueryBuilder($queryBuilder);
+    }
+}

--- a/Classes/Backend/Layout/HideContentElementChildrenEventListener.php
+++ b/Classes/Backend/Layout/HideContentElementChildrenEventListener.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 namespace TYPO3\CMS\ContentBlocks\Backend\Layout;
 
 use TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForContentEvent;
-use TYPO3\CMS\ContentBlocks\Service\TtContentParentField;
+use TYPO3\CMS\ContentBlocks\Service\ContentElementParentFieldService;
 use TYPO3\CMS\Core\Database\Connection;
 
 /**
@@ -27,14 +27,14 @@ use TYPO3\CMS\Core\Database\Connection;
 final class HideContentElementChildrenEventListener
 {
     public function __construct(
-        private readonly TtContentParentField $ttContentParentField
+        private readonly ContentElementParentFieldService $contentElementParentFieldService
     ) {}
 
     public function __invoke(ModifyDatabaseQueryForContentEvent $event): void
     {
         $queryBuilder = $event->getQueryBuilder();
 
-        foreach ($this->ttContentParentField->getAllFieldNames() as $fieldName) {
+        foreach ($this->contentElementParentFieldService->getAllFieldNames() as $fieldName) {
             $queryBuilder->andWhere(
                 $queryBuilder->expr()->eq(
                     $fieldName,

--- a/Classes/Service/ContentElementParentFieldService.php
+++ b/Classes/Service/ContentElementParentFieldService.php
@@ -17,34 +17,38 @@ declare(strict_types=1);
 
 namespace TYPO3\CMS\ContentBlocks\Service;
 
+use TYPO3\CMS\ContentBlocks\Definition\ContentType\ContentType;
 use TYPO3\CMS\ContentBlocks\Definition\TableDefinitionCollection;
 
 /**
  * @internal
  */
-final class TtContentParentField
+final class ContentElementParentFieldService
 {
     public function __construct(
         private readonly TableDefinitionCollection $tableDefinitionCollection
     ) {}
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getAllFieldNames(): array
     {
-        if (!$this->tableDefinitionCollection->hasTable('tt_content')) {
+        $contentElementTable = ContentType::CONTENT_ELEMENT->getTable();
+        if (!$this->tableDefinitionCollection->hasTable($contentElementTable)) {
             return [];
         }
 
         $fieldNames = [];
-        foreach ($this->tableDefinitionCollection->getTable('tt_content')->getParentReferences() as $parentReference) {
+        $contentElementTableDefinition = $this->tableDefinitionCollection->getTable($contentElementTable);
+        foreach ($contentElementTableDefinition->getParentReferences() as $parentReference) {
             $fieldConfiguration = $parentReference->getFieldConfiguration()->getTca()['config'] ?? [];
-            if (($fieldConfiguration['foreign_table'] ?? '') === 'tt_content') {
-                $fieldNames[] = $fieldConfiguration['foreign_field'] ?? '';
+            if (($fieldConfiguration['foreign_table'] ?? '') === $contentElementTable) {
+                $foreignField = $fieldConfiguration['foreign_field'];
+                $fieldNames[$foreignField] = $foreignField;
             }
         }
-
-        return array_values(array_unique(array_filter($fieldNames)));
+        $fieldNameList = array_values($fieldNames);
+        return $fieldNameList;
     }
 }

--- a/Classes/Service/ContentElementParentFieldService.php
+++ b/Classes/Service/ContentElementParentFieldService.php
@@ -20,9 +20,6 @@ namespace TYPO3\CMS\ContentBlocks\Service;
 use TYPO3\CMS\ContentBlocks\Definition\ContentType\ContentType;
 use TYPO3\CMS\ContentBlocks\Definition\TableDefinitionCollection;
 
-/**
- * @internal
- */
 final class ContentElementParentFieldService
 {
     public function __construct(

--- a/Classes/Service/TtContentParentField.php
+++ b/Classes/Service/TtContentParentField.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\ContentBlocks\Service;
+
+use TYPO3\CMS\ContentBlocks\Definition\TableDefinitionCollection;
+
+/**
+ * @internal
+ */
+final class TtContentParentField
+{
+    public function __construct(
+        private readonly TableDefinitionCollection $tableDefintionCollection
+    ) {}
+
+    /**
+     * @return string[]
+     */
+    public function getAllFieldNames(): array
+    {
+        if (!$this->tableDefintionCollection->hasTable('tt_content')) {
+            return [];
+        }
+
+        $fieldNames = [];
+        foreach ($this->tableDefintionCollection->getTable('tt_content')->getParentReferences() as $parentReference) {
+            $fieldConfiguration = $parentReference->getFieldConfiguration()->getTca()['config'] ?? [];
+            if (($fieldConfiguration['foreign_table'] ?? '') === 'tt_content') {
+                $fieldNames[] = $fieldConfiguration['foreign_field'] ?? '';
+            }
+        }
+
+        return array_values(array_unique(array_filter($fieldNames)));
+    }
+}

--- a/Classes/Service/TtContentParentField.php
+++ b/Classes/Service/TtContentParentField.php
@@ -25,7 +25,7 @@ use TYPO3\CMS\ContentBlocks\Definition\TableDefinitionCollection;
 final class TtContentParentField
 {
     public function __construct(
-        private readonly TableDefinitionCollection $tableDefintionCollection
+        private readonly TableDefinitionCollection $tableDefinitionCollection
     ) {}
 
     /**
@@ -33,12 +33,12 @@ final class TtContentParentField
      */
     public function getAllFieldNames(): array
     {
-        if (!$this->tableDefintionCollection->hasTable('tt_content')) {
+        if (!$this->tableDefinitionCollection->hasTable('tt_content')) {
             return [];
         }
 
         $fieldNames = [];
-        foreach ($this->tableDefintionCollection->getTable('tt_content')->getParentReferences() as $parentReference) {
+        foreach ($this->tableDefinitionCollection->getTable('tt_content')->getParentReferences() as $parentReference) {
             $fieldConfiguration = $parentReference->getFieldConfiguration()->getTca()['config'] ?? [];
             if (($fieldConfiguration['foreign_table'] ?? '') === 'tt_content') {
                 $fieldNames[] = $fieldConfiguration['foreign_field'] ?? '';

--- a/Classes/UserFunction/ContentWhere.php
+++ b/Classes/UserFunction/ContentWhere.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace TYPO3\CMS\ContentBlocks\UserFunction;
 
-use TYPO3\CMS\ContentBlocks\Service\TtContentParentField;
+use TYPO3\CMS\ContentBlocks\Service\ContentElementParentFieldService;
 
 /**
  * @internal
@@ -25,14 +25,14 @@ use TYPO3\CMS\ContentBlocks\Service\TtContentParentField;
 final class ContentWhere
 {
     public function __construct(
-        private readonly TtContentParentField $ttContentParentField
+        private readonly ContentElementParentFieldService $contentElementParentFieldService
     ) {}
 
     public function extend(string $where): string
     {
         $columns = array_map(
             fn(string $fieldName): string => ' AND {#' . $fieldName . '} = 0',
-            $this->ttContentParentField->getAllFieldNames()
+            $this->contentElementParentFieldService->getAllFieldNames()
         );
 
         return $where . implode(' ', $columns);

--- a/Classes/UserFunction/ContentWhere.php
+++ b/Classes/UserFunction/ContentWhere.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\ContentBlocks\UserFunction;
+
+use TYPO3\CMS\ContentBlocks\Service\TtContentParentField;
+
+/**
+ * @internal
+ */
+final class ContentWhere
+{
+    public function __construct(
+        private readonly TtContentParentField $ttContentParentField
+    ) {}
+
+    public function extend(string $where): string
+    {
+        $columns = array_map(
+            fn(string $fieldName): string => ' AND {#' . $fieldName . '} = 0',
+            $this->ttContentParentField->getAllFieldNames()
+        );
+
+        return $where . implode(' ', $columns);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -7,6 +7,10 @@ services:
   TYPO3\CMS\ContentBlocks\:
     resource: '../Classes/*'
 
+  TYPO3\CMS\ContentBlocks\UserFunction\:
+    resource: '../Classes/UserFunction/*'
+    public: true
+
 # @todo change to BeforeTcaOverridesEvent for v13
   TYPO3\CMS\ContentBlocks\Generator\TcaGenerator:
     public: true
@@ -58,6 +62,12 @@ services:
       - name: event.listener
         identifier: 'content-blocks-sql'
         event: TYPO3\CMS\Core\Database\Event\AlterTableDefinitionStatementsEvent
+
+  TYPO3\CMS\ContentBlocks\Backend\Layout\HideContentElementChildrenEventListener:
+    tags:
+      - name: event.listener
+        identifier: 'content-blocks-hide-children'
+        event: TYPO3\CMS\Backend\View\Event\ModifyDatabaseQueryForContentEvent
 
   TYPO3\CMS\ContentBlocks\Backend\Preview\PreviewRenderer:
     public: true

--- a/Documentation/Guides/Index.rst
+++ b/Documentation/Guides/Index.rst
@@ -11,7 +11,6 @@ functionality.
 ..  toctree::
     :maxdepth: 2
     :titlesonly:
+    :glob:
 
-    ExtendContentBlockTCA/Index
-    SharedPartials/Index
-    FluidStyledContent/Index
+    */Index

--- a/Documentation/Guides/NestedContentElements/Index.rst
+++ b/Documentation/Guides/NestedContentElements/Index.rst
@@ -5,39 +5,88 @@
 Nested Content Elements
 =======================
 
-It is possible to nest content elements within content blocks.
-TYPO3 by default would render those nested elements within the TYPO3 backend
-module "Page" and the frontend output.
+It is possible to nest Content Elements within Content Blocks.
+By default, TYPO3 would render those nested elements within the TYPO3 Page
+Module in the backend and the frontend output. Content Blocks delivers an API
+and integration for common setups to prevent this unwanted behaviour.
 
-EXT:content_blocks already delivers an API and integration for common setup to
-prevent that unwanted output.
+.. note::
+
+   This will not replace proper grid extensions like EXT:container, as this
+   solution does not provide drag and drop or creation of new child elements
+   in the Page Module.
+
+How to create nested Content Elements
+=====================================
+
+In order to have nested Content Elements, we need to make use of the field type
+:ref:`Collection <field_type_collection>`. This field type allows us to have a
+relation to another table. In our case :sql:`tt_content`.
+
+.. code-block:: yaml
+   :caption: EXT:my_extension/ContentBlocks/ContentElements/tabs/EditorInterface.yaml
+
+    name: example/tabs
+    fields:
+      - identifier: header
+        useExistingField: true
+      - identifier: tabs_item
+        type: Collection
+        minitems: 1
+        foreign_table: tt_content
+        overrideChildTca:
+          columns:
+            CType:
+              config:
+                default: example_text
+
+This config creates a field, where you can create new Content Elements within
+your root Content Element. For better usability the default CType can be
+overridden with :yaml:`overrideChildTca`. Right now, it is not possible to
+restrict certain CTypes.
+
+When to use nested Content Elements vs. container extensions
+============================================================
+
+Many problems can be solved with either solution. However, as a rule of thumb,
+as soon as you need dynamic multi-grid components for your page, you are better
+off using something like EXT:container. For example "Two-Column container",
+"1-1-2 Container" or "Wrapper Container".
+
+On the other hand, if you create a self-contained element, which should hold
+child Content Element relations and these child elements are unlikely to be
+moved elsewhere, you might be better off using simple nested Content Elements.
+An example could be a "Tab module" or a "Content Carousel".
 
 Concept
 =======
 
-The nesting is done via one database field holding a reference to the parent content element.
-The :sql:`colPos` column will always be `0`.
+The nesting is done via one :ref:`database field <field_type_collection_foreign_field>`
+holding a reference to the parent Content Element. The :sql:`colPos` column will
+always be `0`, which is also the reason why it would otherwise be rendered by
+TYPO3 even though created within another Content Element.
 
-.. note::
-
-   This will not remove the need for proper grid extensions like EXT:container.
+Extensions like EXT:container work completely different as they assign a
+specific colPos value to the child elements.
 
 Preventing output in frontend
 =============================
 
-Output in frontend is prevented by extending :typoscript:`styles.content.get.where` condition.
-This is done via the :typoscript:`postUserFunc` which will extract all necessary additional columns.
-Those are than added to the SQL statement in order to prevent fetching of any child elements.
+Output in frontend is prevented by extending :typoscript:`styles.content.get.where`
+condition. This is done via :typoscript:`postUserFunc`, which will extract all
+defined parent reference columns. Those are added to the SQL statement in order
+to prevent fetching any child elements.
 
 .. note::
 
-   You need to integrate the logic yourself if you do not build upon :typoscript:`styles.content.get.where`.
-   The necessary API providing all the columns is available via :php:`TYPO3\CMS\ContentBlocks\Service\TtContentParentField->getAllFieldNames()`.
+   If you do not build upon :typoscript:`styles.content.get.where`, you need to
+   integrate the logic yourself. The necessary API providing all the columns is
+   available via :php:`TYPO3\CMS\ContentBlocks\Service\ContentElementParentFieldService->getAllFieldNames()`.
    This can be used to apply the same approach to :php:`TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor`.
 
 Preventing output in backend
 ============================
 
-TYPO3 provides an event to alter the SQL query to fetch content for the "Page" backend module.
-The EXT:content_blocks adds an event listener which will extract all necessary additional columns.
-Those are than added to the SQL query in order to prevent fetching of any child elements.
+TYPO3 provides an event to alter the SQL query to fetch content for the Page
+Module in the backend. Content Blocks adds an event listener to apply the same
+logic as for the frontend.

--- a/Documentation/Guides/NestedContentElements/Index.rst
+++ b/Documentation/Guides/NestedContentElements/Index.rst
@@ -1,0 +1,43 @@
+.. include:: /Includes.rst.txt
+.. _cb_nestedContentElements:
+
+=======================
+Nested Content Elements
+=======================
+
+It is possible to nest content elements within content blocks.
+TYPO3 by default would render those nested elements within the TYPO3 backend
+module "Page" and the frontend output.
+
+EXT:content_blocks already delivers an API and integration for common setup to
+prevent that unwanted output.
+
+Concept
+=======
+
+The nesting is done via one database field holding a reference to the parent content element.
+The :sql:`colPos` column will always be `0`.
+
+.. note::
+
+   This will not remove the need for proper grid extensions like EXT:container.
+
+Preventing output in frontend
+=============================
+
+Output in frontend is prevented by extending :typoscript:`styles.content.get.where` condition.
+This is done via the :typoscript:`postUserFunc` which will extract all necessary additional columns.
+Those are than added to the SQL statement in order to prevent fetching of any child elements.
+
+.. note::
+
+   You need to integrate the logic yourself if you do not build upon :typoscript:`styles.content.get.where`.
+   The necessary API providing all the columns is available via :php:`TYPO3\CMS\ContentBlocks\Service\TtContentParentField->getAllFieldNames()`.
+   This can be used to apply the same approach to :php:`TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor`.
+
+Preventing output in backend
+============================
+
+TYPO3 provides an event to alter the SQL query to fetch content for the "Page" backend module.
+The EXT:content_blocks adds an event listener which will extract all necessary additional columns.
+Those are than added to the SQL query in order to prevent fetching of any child elements.

--- a/Documentation/YamlReference/FieldTypes/Collection/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Collection/Index.rst
@@ -119,6 +119,7 @@ Settings
       When you use :yaml:`foreign_table` it is not possible to define
       :yaml:`fields` anymore. They will not be evaluated.
 
+.. _field_type_collection_foreign_field:
 .. confval:: foreign_field
 
    :Required: false

--- a/Tests/Unit/Service/ContentElementParentFieldServiceTest.php
+++ b/Tests/Unit/Service/ContentElementParentFieldServiceTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\ContentBlocks\Tests\Unit\Service;
+
+use TYPO3\CMS\ContentBlocks\Definition\Factory\TableDefinitionCollectionFactory;
+use TYPO3\CMS\ContentBlocks\Loader\LoadedContentBlock;
+use TYPO3\CMS\ContentBlocks\Registry\ContentBlockRegistry;
+use TYPO3\CMS\ContentBlocks\Service\ContentElementParentFieldService;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class ContentElementParentFieldServiceTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function uniqueForeignFieldAreCollectedForTtContent(): void
+    {
+        $contentBlocks = [
+            [
+                'name' => 'foo/bar',
+                'icon' => '',
+                'iconProvider' => '',
+                'extPath' => 'EXT:example/ContentBlocks/foo',
+                'yaml' => [
+                    'table' => 'tt_content',
+                    'typeField' => 'CType',
+                    'fields' => [
+                        [
+                            'identifier' => 'nested_content',
+                            'type' => 'Collection',
+                            'foreign_table' => 'tt_content',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'name' => 'foo/baz',
+                'icon' => '',
+                'iconProvider' => '',
+                'extPath' => 'EXT:example/ContentBlocks/baz',
+                'yaml' => [
+                    'table' => 'foobar',
+                    'typeField' => 'CType',
+                    'fields' => [
+                        [
+                            'identifier' => 'nested_content',
+                            'type' => 'Collection',
+                            'foreign_table' => 'tt_content',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'name' => 't3ce/example',
+                'icon' => '',
+                'iconProvider' => '',
+                'extPath' => 'EXT:example/ContentBlocks/example',
+                'yaml' => [
+                    'table' => 'tt_content',
+                    'typeField' => 'CType',
+                    'fields' => [
+                        [
+                            'identifier' => 'nested_content2',
+                            'type' => 'Collection',
+                            'foreign_table' => 'tt_content',
+                            'foreign_field' => 'alternative_foreign_field',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $expected = [
+            'foreign_table_parent_uid',
+            'alternative_foreign_field',
+        ];
+
+        $contentBlockRegistry = new ContentBlockRegistry();
+        foreach ($contentBlocks as $contentBlock) {
+            $contentBlockRegistry->register(LoadedContentBlock::fromArray($contentBlock));
+        }
+        $tableDefinitionCollection = (new TableDefinitionCollectionFactory($contentBlockRegistry))
+            ->create();
+        $contentElementParentFieldService = new ContentElementParentFieldService($tableDefinitionCollection);
+
+        self::assertSame($expected, $contentElementParentFieldService->getAllFieldNames());
+    }
+
+    /**
+     * @test
+     */
+    public function emptyResultIfNoContentElementDefinition(): void
+    {
+        $contentBlocks = [
+            [
+                'name' => 'foo/bar',
+                'icon' => '',
+                'iconProvider' => '',
+                'extPath' => 'EXT:example/ContentBlocks/foo',
+                'yaml' => [
+                    'table' => 'foobar',
+                    'typeField' => 'CType',
+                    'fields' => [
+                        [
+                            'identifier' => 'nested_content',
+                            'type' => 'Collection',
+                            'foreign_table' => 'tt_content',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'name' => 't3ce/example',
+                'icon' => '',
+                'iconProvider' => '',
+                'extPath' => 'EXT:example/ContentBlocks/example',
+                'yaml' => [
+                    'table' => 'foobar',
+                    'typeField' => 'CType',
+                    'fields' => [
+                        [
+                            'identifier' => 'nested_content2',
+                            'type' => 'Collection',
+                            'foreign_table' => 'tt_content',
+                            'foreign_field' => 'alternative_foreign_field',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $expected = [];
+
+        $contentBlockRegistry = new ContentBlockRegistry();
+        foreach ($contentBlocks as $contentBlock) {
+            $contentBlockRegistry->register(LoadedContentBlock::fromArray($contentBlock));
+        }
+        $tableDefinitionCollection = (new TableDefinitionCollectionFactory($contentBlockRegistry))
+            ->create();
+        $contentElementParentFieldService = new ContentElementParentFieldService($tableDefinitionCollection);
+
+        self::assertSame($expected, $contentElementParentFieldService->getAllFieldNames());
+    }
+}

--- a/ext_typoscript_setup.typoscript
+++ b/ext_typoscript_setup.typoscript
@@ -1,0 +1,1 @@
+styles.content.get.select.where.postUserFunc = TYPO3\CMS\ContentBlocks\UserFunction\ContentWhere->extend


### PR DESCRIPTION
We integrate the basics for a default TYPO3 in order to prevent rendering of nested elements in Page module within backend, as well as styles.content.get TypoScript rendering for frontend.

We also document the technical approach and how to use the API for custom implementations and other rendering approaches, e.g. via DatabaseQueryProcessor.

"Basic" because we do not add rendering of the childs as ready to use columns for frontend or backend, this will be part of #68.

Resolves: #106