### PR TITLE
Add docs labeledcheckbox

### DIFF
--- a/Documentation/YamlReference/FieldTypes/Checkbox/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Checkbox/Index.rst
@@ -60,6 +60,7 @@ Settings
 
    :Required: no
    :Type: string
+   :Default: default
 
    *  :yaml:`default`
    *  :yaml:`checkboxToggle`

--- a/Documentation/YamlReference/FieldTypes/Checkbox/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Checkbox/Index.rst
@@ -56,6 +56,15 @@ Settings
             </trans-unit>
         </body>
 
+.. confval:: renderType
+
+   :Required: no
+   :Type: string
+
+   *  :yaml:`default`
+   *  :yaml:`checkboxToggle`
+   *  :yaml:`checkboxLabeledToggle`
+
 For advanced configuration refer to the :ref:`TCA documentation <t3tca:columns-check>`.
 
 Examples
@@ -99,3 +108,18 @@ Toggle checkbox:
         type: Checkbox
         renderType: checkboxToggle
         default: 1
+
+Labeled toggle checkbox:
+
+.. code-block:: yaml
+
+    name: example/checkbox
+    fields:
+      - identifier: toggle
+        type: Checkbox
+        renderType: checkboxLabeledToggle
+        items:
+          - label: 'Your label'
+            labelChecked: 'Label checked'
+            labelUnchecked: 'Label unchecked'
+            invertStateDisplay: true

--- a/Documentation/YamlReference/FieldTypes/Checkbox/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Checkbox/Index.rst
@@ -60,9 +60,8 @@ Settings
 
    :Required: no
    :Type: string
-   :Default: default
+   :Default: check
 
-   *  :yaml:`default`
    *  :yaml:`checkboxToggle`
    *  :yaml:`checkboxLabeledToggle`
 

--- a/Documentation/YamlReference/FieldTypes/Relation/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Relation/Index.rst
@@ -66,7 +66,7 @@ Advanced / use case
       - identifier: page_select
         type: Relation
         allowed: 'pages'
-        maxitems: 1,
+        maxitems: 1
         suggestOptions:
           default:
             additionalSearchFields: 'nav_title, url'


### PR DESCRIPTION
This adds an example for a labeledCheckBox
It also fixes an issue with a comma inside an example