### PR TITLE
[FEATURE] Add Support for TYPO3 v13.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,8 +52,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
         TYPO3: [ '12.4' ]
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+
+      - uses: actions/checkout@v3
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer require typo3/cms-core:^${{ matrix.TYPO3 }} --prefer-dist --prefer-stable --no-progress
+
+      - name: Unit
+        run: Build/Scripts/runTests.sh -s unit -p ${{ matrix.php }}
+
+  unit_tests_13:
+    name: Unit Tests TYPO3 v${{ matrix.TYPO3 }} PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.2', '8.3' ]
+        TYPO3: [ '13.0' ]
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -118,7 +151,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
         TYPO3: [ '12.4' ]
     steps:
       - name: Setup PHP
@@ -144,6 +177,39 @@ jobs:
 
       - name: Functional
         run: Build/Scripts/runTests.sh -s functional -d sqlite -p ${{ matrix.php }}
+
+  # functional_tests_13:
+  #   name: Functional Tests TYPO3 v${{ matrix.TYPO3 }} PHP ${{ matrix.php }}
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       php: [ '8.2', '8.3' ]
+  #       TYPO3: [ '13.0' ]
+  #   steps:
+  #     - name: Setup PHP
+  #       uses: shivammathur/setup-php@v2
+  #       with:
+  #         php-version: ${{ matrix.php }}
+
+  #     - uses: actions/checkout@v3
+
+  #     - name: Get composer cache directory
+  #       id: composer-cache
+  #       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+  #     - name: Cache dependencies
+  #       uses: actions/cache@v3
+  #       with:
+  #         path: ${{ steps.composer-cache.outputs.dir }}
+  #         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+  #         restore-keys: ${{ runner.os }}-composer-
+
+  #     - name: Install dependencies
+  #       run: composer require typo3/cms-core:^${{ matrix.TYPO3 }} --prefer-stable --no-progress
+
+  #     - name: Functional
+  #       run: Build/Scripts/runTests.sh -s functional -d sqlite -p ${{ matrix.php }}
 
 #  functional_tests_dev:
 #    name: Functional Tests TYPO3 v${{ matrix.TYPO3 }} PHP ${{ matrix.php }}

--- a/Build/phpunit/FunctionalTestsBootstrap.php
+++ b/Build/phpunit/FunctionalTestsBootstrap.php
@@ -16,7 +16,7 @@
  * This file is defined in FunctionalTests.xml and called by phpunit
  * before instantiating the test suites.
  */
-(static function () {
+(static function() {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
     $testbase->defineOriginalRootPath();
     $testbase->createDirectory(ORIGINAL_ROOT . 'var/tests');

--- a/Build/phpunit/UnitTestsBootstrap.php
+++ b/Build/phpunit/UnitTestsBootstrap.php
@@ -16,7 +16,7 @@
  * This file is defined in UnitTests.xml and called by phpunit
  * before instantiating the test suites.
  */
-(static function () {
+(static function() {
     $testbase = new \TYPO3\TestingFramework\Core\Testbase();
 
     // These if's are for core testing (package typo3/cms) only. cms-composer-installer does

--- a/Classes/Basics/BasicsLoader.php
+++ b/Classes/Basics/BasicsLoader.php
@@ -49,7 +49,7 @@ class BasicsLoader
             return $this->basicsRegistry;
         }
         $this->basicsRegistry = $this->loadUncached();
-        $cache = array_map(fn(LoadedBasic $basic): array => $basic->toArray(), $this->basicsRegistry->getAllBasics());
+        $cache = array_map(fn (LoadedBasic $basic): array => $basic->toArray(), $this->basicsRegistry->getAllBasics());
         $this->cache->set('content-blocks-basics', 'return ' . var_export($cache, true) . ';');
         return $this->basicsRegistry;
     }

--- a/Classes/Command/CreateContentBlockCommand.php
+++ b/Classes/Command/CreateContentBlockCommand.php
@@ -213,7 +213,7 @@ class CreateContentBlockCommand extends Command
      */
     protected function getPackageTitles(array $availablePackages): array
     {
-        return array_map(fn(PackageInterface $package): string => $package->getPackageMetaData()->getTitle(), $availablePackages);
+        return array_map(fn (PackageInterface $package): string => $package->getPackageMetaData()->getTitle(), $availablePackages);
     }
 
     /**
@@ -222,7 +222,7 @@ class CreateContentBlockCommand extends Command
      */
     protected function getPackageKeys(array $availablePackages): array
     {
-        return array_map(fn(PackageInterface $package): string => $package->getPackageKey(), $availablePackages);
+        return array_map(fn (PackageInterface $package): string => $package->getPackageKey(), $availablePackages);
     }
 
     /**

--- a/Classes/Command/ListContentBlocksCommand.php
+++ b/Classes/Command/ListContentBlocksCommand.php
@@ -56,7 +56,7 @@ class ListContentBlocksCommand extends Command
             return Command::SUCCESS;
         }
 
-        usort($availableContentBlocks, function (array $a, array $b) use ($order): int {
+        usort($availableContentBlocks, function(array $a, array $b) use ($order): int {
             if ($order === 'content-type') {
                 return $a[$order] <=> $b[$order];
             }

--- a/Classes/CompatibilityLayer/TcaPreparation.php
+++ b/Classes/CompatibilityLayer/TcaPreparation.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\ContentBlocks\CompatibilityLayer;
+
+if (class_exists(\TYPO3\CMS\Core\Preparations\TcaPreparation::class)) {
+    class TcaPreparation extends \TYPO3\CMS\Core\Preparations\TcaPreparation {}
+} elseif (class_exists(\TYPO3\CMS\Core\Configuration\Tca\TcaPreparation::class)) {
+    class TcaPreparation extends \TYPO3\CMS\Core\Configuration\Tca\TcaPreparation {}
+} else {
+    throw new \Exception('Could not find TcaPreparation class.', 1707468989);
+}

--- a/Classes/Definition/ContentType/ContentTypeDefinitionCollection.php
+++ b/Classes/Definition/ContentType/ContentTypeDefinitionCollection.php
@@ -85,7 +85,7 @@ final class ContentTypeDefinitionCollection implements \IteratorAggregate, \Coun
     private function sort(): array
     {
         $types = $this->definitions;
-        usort($types, fn(ContentTypeInterface $a, ContentTypeInterface $b): int => $b->getPriority() <=> $a->getPriority());
+        usort($types, fn (ContentTypeInterface $a, ContentTypeInterface $b): int => $b->getPriority() <=> $a->getPriority());
         return $types;
     }
 }

--- a/Classes/Definition/Factory/TableDefinitionCollectionFactory.php
+++ b/Classes/Definition/Factory/TableDefinitionCollectionFactory.php
@@ -873,7 +873,7 @@ final class TableDefinitionCollectionFactory implements SingletonInterface
         $this->assertTypeExists($field, $input);
         $fieldType = FieldType::tryFrom($field['type']);
         if ($fieldType === null) {
-            $validTypesList = array_map(fn(FieldType $fieldType) => $fieldType->value, FieldType::cases());
+            $validTypesList = array_map(fn (FieldType $fieldType) => $fieldType->value, FieldType::cases());
             $validTypes = implode(', ', $validTypesList);
             throw new \InvalidArgumentException(
                 'The type "' . $field['type'] . '" is not a valid type in Content Block "' . $input->contentBlock->getName() . '". Valid types are: ' . $validTypes . '.',

--- a/Classes/FieldConfiguration/FileFieldConfiguration.php
+++ b/Classes/FieldConfiguration/FileFieldConfiguration.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
 
 namespace TYPO3\CMS\ContentBlocks\FieldConfiguration;
 
-use TYPO3\CMS\Core\Preparations\TcaPreparation;
+use TYPO3\CMS\ContentBlocks\CompatibilityLayer\TcaPreparation;
 use TYPO3\CMS\Core\Resource\AbstractFile;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 

--- a/Classes/Generator/TcaGenerator.php
+++ b/Classes/Generator/TcaGenerator.php
@@ -19,6 +19,7 @@ namespace TYPO3\CMS\ContentBlocks\Generator;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\ContentBlocks\Backend\Preview\PreviewRenderer;
+use TYPO3\CMS\ContentBlocks\CompatibilityLayer\TcaPreparation;
 use TYPO3\CMS\ContentBlocks\Definition\Capability\RootLevelType;
 use TYPO3\CMS\ContentBlocks\Definition\ContentType\ContentType;
 use TYPO3\CMS\ContentBlocks\Definition\ContentType\ContentTypeInterface;
@@ -33,7 +34,6 @@ use TYPO3\CMS\ContentBlocks\FieldConfiguration\FlexFormFieldConfiguration;
 use TYPO3\CMS\ContentBlocks\Registry\LanguageFileRegistry;
 use TYPO3\CMS\ContentBlocks\Service\SystemExtensionAvailability;
 use TYPO3\CMS\Core\Configuration\Event\AfterTcaCompilationEvent;
-use TYPO3\CMS\Core\Preparations\TcaPreparation;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 

--- a/Classes/Loader/ContentBlockLoader.php
+++ b/Classes/Loader/ContentBlockLoader.php
@@ -82,7 +82,7 @@ class ContentBlockLoader
         }
 
         if (is_array($contentBlocks = $this->cache->require('content-blocks'))) {
-            $contentBlocks = array_map(fn(array $contentBlock): LoadedContentBlock => LoadedContentBlock::fromArray($contentBlock), $contentBlocks);
+            $contentBlocks = array_map(fn (array $contentBlock): LoadedContentBlock => LoadedContentBlock::fromArray($contentBlock), $contentBlocks);
             $contentBlockRegistry = new ContentBlockRegistry();
             foreach ($contentBlocks as $contentBlock) {
                 $contentBlockRegistry->register($contentBlock);
@@ -113,7 +113,7 @@ class ContentBlockLoader
             }
         }
         $loadedContentBlocks = array_merge([], ...$loadedContentBlocks);
-        $sortByPriority = fn(LoadedContentBlock $a, LoadedContentBlock $b): int => (int)($b->getYaml()['priority'] ?? 0) <=> (int)($a->getYaml()['priority'] ?? 0);
+        $sortByPriority = fn (LoadedContentBlock $a, LoadedContentBlock $b): int => (int)($b->getYaml()['priority'] ?? 0) <=> (int)($a->getYaml()['priority'] ?? 0);
         usort($loadedContentBlocks, $sortByPriority);
         $contentBlockRegistry = new ContentBlockRegistry();
         foreach ($loadedContentBlocks as $contentBlock) {
@@ -123,7 +123,7 @@ class ContentBlockLoader
 
         $this->publishAssets($loadedContentBlocks);
 
-        $cache = array_map(fn(LoadedContentBlock $contentBlock): array => $contentBlock->toArray(), $loadedContentBlocks);
+        $cache = array_map(fn (LoadedContentBlock $contentBlock): array => $contentBlock->toArray(), $loadedContentBlocks);
         $this->cache->set('content-blocks', 'return ' . var_export($cache, true) . ';');
 
         return $this->contentBlockRegistry;

--- a/Classes/Service/PackageResolver.php
+++ b/Classes/Service/PackageResolver.php
@@ -61,7 +61,7 @@ class PackageResolver
      */
     protected function removeFrameworkExtensions(array $packages): array
     {
-        return array_filter($packages, fn(PackageInterface $package): bool => !$package->getPackageMetaData()->isFrameworkType());
+        return array_filter($packages, fn (PackageInterface $package): bool => !$package->getPackageMetaData()->isFrameworkType());
     }
 
     /**
@@ -80,7 +80,7 @@ class PackageResolver
         foreach ($composerLockPackages as $package) {
             $composerLockMap[$package['name']] = $package['dist']['type'] ?? null;
         }
-        $filterPackages = function (PackageInterface $package) use ($composerLockMap): bool {
+        $filterPackages = function(PackageInterface $package) use ($composerLockMap): bool {
             $name = $package->getValueFromComposerManifest('name');
             if (array_key_exists($name, $composerLockMap)) {
                 return $composerLockMap[$name] === 'path';

--- a/Classes/UserFunction/ContentWhere.php
+++ b/Classes/UserFunction/ContentWhere.php
@@ -29,7 +29,7 @@ class ContentWhere
     public function extend(string $where): string
     {
         $columns = array_map(
-            fn(string $fieldName): string => ' AND {#' . $fieldName . '} = 0',
+            fn (string $fieldName): string => ' AND {#' . $fieldName . '} = 0',
             $this->parentFieldNames
         );
 

--- a/Tests/Unit/FieldTypes/FileFieldConfigurationTest.php
+++ b/Tests/Unit/FieldTypes/FileFieldConfigurationTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace TYPO3\CMS\ContentBlocks\Tests\Unit\FieldTypes;
 
 use TYPO3\CMS\ContentBlocks\FieldConfiguration\FileFieldConfiguration;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Resource\AbstractFile;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -25,6 +26,11 @@ final class FileFieldConfigurationTest extends UnitTestCase
 {
     public static function getTcaReturnsExpectedTcaDataProvider(): iterable
     {
+        $imageExtensions = 'gif,jpg,jpeg,tif,tiff,bmp,pcx,tga,png,pdf,ai,svg';
+        if ((new Typo3Version())->getMajorVersion() >= 13) {
+            $imageExtensions .= ',webp';
+        }
+
         yield 'truthy values' => [
             'config' => [
                 'label' => 'foo',
@@ -96,7 +102,7 @@ final class FileFieldConfigurationTest extends UnitTestCase
                 'exclude' => true,
                 'config' => [
                     'type' => 'file',
-                    'allowed' => 'gif,jpg,jpeg,tif,tiff,bmp,pcx,tga,png,pdf,ai,svg',
+                    'allowed' => $imageExtensions,
                     'disallowed' => 'png',
                     'appearance' => [
                         'foo' => 'bar',
@@ -203,7 +209,7 @@ final class FileFieldConfigurationTest extends UnitTestCase
                 'exclude' => true,
                 'config' => [
                     'type' => 'file',
-                    'allowed' => 'gif,jpg,jpeg,tif,tiff,bmp,pcx,tga,png,pdf,ai,svg',
+                    'allowed' => $imageExtensions,
                     'disallowed' => ['png'],
                 ],
             ],

--- a/Tests/Unit/Generator/TcaGeneratorTest.php
+++ b/Tests/Unit/Generator/TcaGeneratorTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace TYPO3\CMS\ContentBlocks\Tests\Unit\Generator;
 
 use TYPO3\CMS\ContentBlocks\Backend\Preview\PreviewRenderer;
+use TYPO3\CMS\ContentBlocks\CompatibilityLayer\TcaPreparation;
 use TYPO3\CMS\ContentBlocks\Definition\Factory\TableDefinitionCollectionFactory;
 use TYPO3\CMS\ContentBlocks\Generator\FlexFormGenerator;
 use TYPO3\CMS\ContentBlocks\Generator\TcaGenerator;
@@ -27,7 +28,6 @@ use TYPO3\CMS\ContentBlocks\Tests\Unit\Fixtures\NoopLanguageFileRegistry;
 use TYPO3\CMS\ContentBlocks\Tests\Unit\Fixtures\TestSystemExtensionAvailability;
 use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
 use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
-use TYPO3\CMS\Core\Preparations\TcaPreparation;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 final class TcaGeneratorTest extends UnitTestCase
@@ -2089,7 +2089,7 @@ final class TcaGeneratorTest extends UnitTestCase
         $baseTca['tt_content']['ctrl']['searchFields'] = 'header,header_link,subheader,bodytext,pi_flexform';
         $GLOBALS['TCA'] = $baseTca;
 
-        $contentBlocks = array_map(fn(array $contentBlock) => LoadedContentBlock::fromArray($contentBlock), $contentBlocks);
+        $contentBlocks = array_map(fn (array $contentBlock) => LoadedContentBlock::fromArray($contentBlock), $contentBlocks);
         $contentBlockRegistry = new ContentBlockRegistry();
         foreach ($contentBlocks as $contentBlock) {
             $contentBlockRegistry->register($contentBlock);
@@ -2257,7 +2257,7 @@ final class TcaGeneratorTest extends UnitTestCase
         ];
         $GLOBALS['TCA'] = $baseTca;
 
-        $contentBlocks = array_map(fn(array $contentBlock) => LoadedContentBlock::fromArray($contentBlock), $contentBlocks);
+        $contentBlocks = array_map(fn (array $contentBlock) => LoadedContentBlock::fromArray($contentBlock), $contentBlocks);
         $contentBlockRegistry = new ContentBlockRegistry();
         foreach ($contentBlocks as $contentBlock) {
             $contentBlockRegistry->register($contentBlock);

--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,13 @@
 			"typo3/cms-composer-installers": true
 		}
 	},
+	"minimum-stability": "RC",
+	"prefer-stable": true,
 	"require": {
-		"typo3/cms-backend": "^12.4",
-		"typo3/cms-core": "^12.4",
-		"typo3/cms-fluid": "^12.4",
-		"typo3/cms-frontend": "^12.4"
+		"typo3/cms-backend": "^12.4 || 13.0",
+		"typo3/cms-core": "^13.0",
+		"typo3/cms-fluid": "^12.4 || 13.0",
+		"typo3/cms-frontend": "^12.4 || 13.0"
 	},
 	"replace": {
 		"typo3/cms-content-blocks": "*"
@@ -48,7 +50,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-main": "13.0.x-dev"
+			"dev-main": "13.1.x-dev"
 		},
 		"typo3/cms": {
 			"web-dir": ".Build/public",
@@ -77,15 +79,15 @@
 		"friendsoftypo3/phpstan-typo3": "^0.9.0",
 		"phpstan/phpstan": "^1.10.22",
 		"phpstan/phpstan-phpunit": "^1.3.13",
-		"typo3/cms-extbase": "^12.4",
-		"typo3/cms-extensionmanager": "^12.4",
-		"typo3/cms-filelist": "^12.4",
-		"typo3/cms-install": "^12.4",
-		"typo3/cms-lowlevel": "^12.4",
-		"typo3/cms-rte-ckeditor": "^12.4",
-		"typo3/cms-tstemplate": "^12.4",
-		"typo3/cms-workspaces": "^12.4",
-		"typo3/coding-standards": "^0.7",
+		"typo3/cms-extbase": "^12.4 || 13.0",
+		"typo3/cms-extensionmanager": "^12.4 || 13.0",
+		"typo3/cms-filelist": "^12.4 || 13.0",
+		"typo3/cms-install": "^12.4 || 13.0",
+		"typo3/cms-lowlevel": "^12.4 || 13.0",
+		"typo3/cms-rte-ckeditor": "^12.4 || 13.0",
+		"typo3/cms-tstemplate": "^12.4 || 13.0",
+		"typo3/cms-workspaces": "^12.4 || 13.0",
+		"typo3/coding-standards": "dev-main",
 		"typo3/testing-framework": "^8.0"
 	},
 	"scripts": {


### PR DESCRIPTION
Only 13.0 as this is released and this extension should be used by end users. We don't expect them to run on current main.

Pinning to 13.0 allows us to prepare a release compatible with v13.1, without letting users run into troubles.