### PR TITLE
Fix missing _raw for relations to none content block tables

### DIFF
--- a/Classes/DataProcessing/RelationResolver.php
+++ b/Classes/DataProcessing/RelationResolver.php
@@ -155,11 +155,10 @@ class RelationResolver
                 tcaFieldConf: $tcaFieldConfig['config'] ?? []
             );
             $result = $this->enrichWithTableAndRawRecordInternal($result, $foreignTable);
-            // If this table is not defined by Content Blocks, return data unprocessed.
-            if (!$this->tableDefinitionCollection->hasTable($foreignTable)) {
-                return $result;
+            // If this table is defined by Content Blocks, process child relations.
+            if ($this->tableDefinitionCollection->hasTable($foreignTable)) {
+                $result = $this->processChildRelations($result);
             }
-            $result = $this->processChildRelations($result);
             if (($tcaFieldConfig['config']['renderType'] ?? '') === 'selectSingle') {
                 return $result[0] ?? null;
             }
@@ -240,11 +239,10 @@ class RelationResolver
             tcaFieldConf: $tcaFieldConfig['config'] ?? []
         );
         $result = $this->enrichWithTableAndRawRecordInternal($result, $collectionTable);
-        // If this table is not defined by Content Blocks, return data unprocessed.
-        if (!$this->tableDefinitionCollection->hasTable($collectionTable)) {
-            return $result;
+        // If this table is defined by Content Blocks, process child relations.
+        if ($this->tableDefinitionCollection->hasTable($collectionTable)) {
+            $result = $this->processChildRelations($result);
         }
-        $result = $this->processChildRelations($result);
         return $result;
     }
 

--- a/Tests/Fixtures/Extensions/test_content_blocks_b/Configuration/TCA/native_record.php
+++ b/Tests/Fixtures/Extensions/test_content_blocks_b/Configuration/TCA/native_record.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'ctrl' => [
+        'title' => 'Native record',
+        'label' => 'title',
+        'security' => [
+            'ignorePageTypeRestriction' => true,
+        ],
+    ],
+    'types' => [
+        '0' => [
+            'showitem' => 'value_1',
+        ],
+    ],
+    'columns' => [
+        'title' => [
+            'label' => 'Title',
+            'config' => [
+                'type' => 'input',
+            ],
+        ],
+    ],
+];

--- a/Tests/Fixtures/Extensions/test_content_blocks_b/ContentBlocks/ContentElements/content-element-b/EditorInterface.yaml
+++ b/Tests/Fixtures/Extensions/test_content_blocks_b/ContentBlocks/ContentElements/content-element-b/EditorInterface.yaml
@@ -88,7 +88,6 @@ fields:
             value: '2'
           - label: 'Foo 3'
             value: '3'
-
       - identifier: select_foreign
         type: Select
         renderType: selectSingle
@@ -97,6 +96,14 @@ fields:
         type: Select
         renderType: selectMultipleSideBySide
         foreign_table: test_record
+      - identifier: select_foreign_native
+        type: Select
+        renderType: selectSingle
+        foreign_table: native_record
+      - identifier: select_foreign_native_multiple
+        type: Select
+        renderType: selectMultipleSideBySide
+        foreign_table: native_record
   - identifier: flexfield
     type: FlexForm
     fields:

--- a/Tests/Fixtures/Extensions/test_content_blocks_b/ext_tables.sql
+++ b/Tests/Fixtures/Extensions/test_content_blocks_b/ext_tables.sql
@@ -1,0 +1,3 @@
+CREATE TABLE native_record (
+	title varchar(255) DEFAULT '' NOT NULL
+);

--- a/Tests/Functional/DataProcessing/Fixtures/DataSet/select_foreign_native.csv
+++ b/Tests/Functional/DataProcessing/Fixtures/DataSet/select_foreign_native.csv
@@ -1,0 +1,4 @@
+"native_record"
+,"uid","pid","title",
+,1,1,"Record 1",0
+,2,1,"Record 2",0

--- a/Tests/Functional/DataProcessing/RelationResolverTest.php
+++ b/Tests/Functional/DataProcessing/RelationResolverTest.php
@@ -559,6 +559,48 @@ final class RelationResolverTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function canResolveSelectForeignNativeTableSingle(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DataSet/select_foreign_native.csv');
+        $contentBlockRegistry = $this->get(ContentBlockRegistry::class);
+        $tableDefinitionCollection = $this->get(TableDefinitionCollectionFactory::class)->create($contentBlockRegistry);
+        $tableDefinition = $tableDefinitionCollection->getTable('tt_content');
+        $elementDefinition = $tableDefinition->getContentTypeDefinitionCollection()->getType('typo3tests_contentelementb');
+        $fieldDefinition = $tableDefinition->getTcaFieldDefinitionCollection()->getField('typo3tests_contentelementb_select_foreign_native');
+        $dummyRecord = [
+            'uid' => 1,
+            'typo3tests_contentelementb_select_foreign_native' => '1',
+        ];
+
+        $relationResolver = new RelationResolver($tableDefinitionCollection, new FlexFormService());
+        $result = $relationResolver->processField($fieldDefinition, $elementDefinition, $dummyRecord, 'tt_content');
+
+        self::assertSame('Record 1', $result['title']);
+    }
+
+    #[Test]
+    public function canResolveSelectForeignNativeTableMultiple(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/DataSet/select_foreign_native.csv');
+        $contentBlockRegistry = $this->get(ContentBlockRegistry::class);
+        $tableDefinitionCollection = $this->get(TableDefinitionCollectionFactory::class)->create($contentBlockRegistry);
+        $tableDefinition = $tableDefinitionCollection->getTable('tt_content');
+        $elementDefinition = $tableDefinition->getContentTypeDefinitionCollection()->getType('typo3tests_contentelementb');
+        $fieldDefinition = $tableDefinition->getTcaFieldDefinitionCollection()->getField('typo3tests_contentelementb_select_foreign_native_multiple');
+        $dummyRecord = [
+            'uid' => 1,
+            'typo3tests_contentelementb_select_foreign_native_multiple' => '1,2',
+        ];
+
+        $relationResolver = new RelationResolver($tableDefinitionCollection, new FlexFormService());
+        $result = $relationResolver->processField($fieldDefinition, $elementDefinition, $dummyRecord, 'tt_content');
+
+        self::assertCount(2, $result);
+        self::assertSame('Record 1', $result[0]['title']);
+        self::assertSame('Record 2', $result[1]['title']);
+    }
+
+    #[Test]
     public function canResolveSelectForeignTableRecursive(): void
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/DataSet/select_foreign_recursive.csv');


### PR DESCRIPTION
Content Block elements might have a relation to none content block tables, e.g. to sys_category.
Those were not properly enriched, leading to follow up issues.

The corresponding code is now extracted and always called.

Resolves: #134