### PR TITLE
[BUGFIX] Collection with new table can not be shared across tables or fields

### DIFF
--- a/Classes/Definition/Factory/ContentBlockCompiler.php
+++ b/Classes/Definition/Factory/ContentBlockCompiler.php
@@ -514,16 +514,15 @@ final class ContentBlockCompiler
 
     private function assignRelationConfigToCollectionField(array $field, ProcessedFieldsResult $result): void
     {
-        $isExternalCollection = array_key_exists('foreign_table', $field);
         $result->tcaFieldDefinition['config']['foreign_field'] ??= 'foreign_table_parent_uid';
-        if ($isExternalCollection) {
-            if ($field['shareAcrossTables'] ?? false) {
-                $result->tcaFieldDefinition['config']['foreign_table_field'] ??= 'tablenames';
-            }
-            if ($field['shareAcrossFields'] ?? false) {
-                $result->tcaFieldDefinition['config']['foreign_match_fields']['fieldname'] = $result->uniqueIdentifier;
-            }
-        } else {
+        if ($field['shareAcrossTables'] ?? false) {
+            $result->tcaFieldDefinition['config']['foreign_table_field'] ??= 'tablenames';
+        }
+        if ($field['shareAcrossFields'] ?? false) {
+            $result->tcaFieldDefinition['config']['foreign_match_fields']['fieldname'] = $result->uniqueIdentifier;
+        }
+        $isExternalCollection = array_key_exists('foreign_table', $field);
+        if (!$isExternalCollection) {
             $result->tcaFieldDefinition['config']['foreign_table'] = $field['table'] ?? $result->uniqueIdentifier;
         }
     }


### PR DESCRIPTION
Always check for `shareAcrossTables` and `shareAcrossFields` and set `foreign_table_field` and `foreign_match_fields` accordingly, regardless of wether `foreign_table` is set (external/existing table) or not (new table).

Fixes #153 