### PR TITLE
Feature: Linebreaks can be marked as context-specific

### DIFF
--- a/Classes/Definition/Factory/ContentBlockCompiler.php
+++ b/Classes/Definition/Factory/ContentBlockCompiler.php
@@ -382,8 +382,10 @@ final class ContentBlockCompiler
         $rootFieldType = $this->resolveType($input, $rootField);
         $fieldTypeEnum = FieldType::tryFrom($rootFieldType::getName());
         if ($fieldTypeEnum !== null) {
-            if(!$this->assertNoLinebreakOutsideOfPalette($fieldTypeEnum, $input->contentBlock, $rootField['assertIfNotInPalette'] ?? true))
+            if ($fieldTypeEnum === FieldType::LINEBREAK && ($rootField['ignoreIfNotInPalette'] ?? false)) {
                 return [];
+            }
+            $this->assertNoLinebreakOutsideOfPalette($fieldTypeEnum, $input->contentBlock);
         }
         $fields = match ($fieldTypeEnum) {
             Fieldtype::PALETTE => $this->handlePalette($input, $result, $rootField),
@@ -879,19 +881,14 @@ final class ContentBlockCompiler
         return $languagePath;
     }
 
-    private function assertNoLinebreakOutsideOfPalette(FieldType $fieldType, LoadedContentBlock $contentBlock, bool $assert): bool
+    private function assertNoLinebreakOutsideOfPalette(FieldType $fieldType, LoadedContentBlock $contentBlock): void
     {
         if ($fieldType === FieldType::LINEBREAK) {
-            if($assert)
-                throw new \InvalidArgumentException(
-                    'Linebreaks are only allowed within Palettes in Content Block "' . $contentBlock->getName() . '".',
-                    1679224392
-                );
-            else
-                return false;
+            throw new \InvalidArgumentException(
+                'Linebreaks are only allowed within Palettes in Content Block "' . $contentBlock->getName() . '".',
+                1679224392
+            );
         }
-
-        return true;
     }
 
     private function assertIdentifierExists(array $field, ProcessingInput $input): void

--- a/Classes/Definition/Factory/ContentBlockCompiler.php
+++ b/Classes/Definition/Factory/ContentBlockCompiler.php
@@ -382,7 +382,8 @@ final class ContentBlockCompiler
         $rootFieldType = $this->resolveType($input, $rootField);
         $fieldTypeEnum = FieldType::tryFrom($rootFieldType::getName());
         if ($fieldTypeEnum !== null) {
-            $this->assertNoLinebreakOutsideOfPalette($fieldTypeEnum, $input->contentBlock);
+            if(!$this->assertNoLinebreakOutsideOfPalette($fieldTypeEnum, $input->contentBlock, $rootField['assertIfNotInPalette'] ?? true))
+                return [];
         }
         $fields = match ($fieldTypeEnum) {
             Fieldtype::PALETTE => $this->handlePalette($input, $result, $rootField),
@@ -878,14 +879,19 @@ final class ContentBlockCompiler
         return $languagePath;
     }
 
-    private function assertNoLinebreakOutsideOfPalette(FieldType $fieldType, LoadedContentBlock $contentBlock): void
+    private function assertNoLinebreakOutsideOfPalette(FieldType $fieldType, LoadedContentBlock $contentBlock, bool $assert): bool
     {
         if ($fieldType === FieldType::LINEBREAK) {
-            throw new \InvalidArgumentException(
-                'Linebreaks are only allowed within Palettes in Content Block "' . $contentBlock->getName() . '".',
-                1679224392
-            );
+            if($assert)
+                throw new \InvalidArgumentException(
+                    'Linebreaks are only allowed within Palettes in Content Block "' . $contentBlock->getName() . '".',
+                    1679224392
+                );
+            else
+                return false;
         }
+
+        return true;
     }
 
     private function assertIdentifierExists(array $field, ProcessingInput $input): void

--- a/Documentation/YamlReference/FieldTypes/Linebreak/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Linebreak/Index.rst
@@ -10,6 +10,22 @@ linebreak. Otherwise all fields within a Palette are displayed next to each
 other. Note: Contrary to all other field types, Linebreaks don't need an
 :yaml:`identifier`.
 
+Settings
+========
+
+.. confval:: ignoreIfNotInPalette
+   :name: ignoreIfNotInPalette
+
+   :Required: false
+   :Type: boolean
+   :Default: false
+
+   Normally, linebreaks can only be defined inside of a palette. With this flag
+   set to true, linebreaks can also appear outside of palettes (but do nothing).
+   This is especially useful in combination with
+   :ref:`Basics <field_type_basic>` when you want a set of fields to be used
+   both in palettes and on root level.
+
 Examples
 ========
 

--- a/Tests/Unit/Definition/Factory/ContentBlockCompilerTest.php
+++ b/Tests/Unit/Definition/Factory/ContentBlockCompilerTest.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\ContentBlocks\Tests\Unit\Fixtures\FieldTypeRegistryTestFactory;
 use TYPO3\CMS\Core\Cache\Frontend\NullFrontend;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
-final class TableDefinitionCollectionFactoryTest extends UnitTestCase
+final class ContentBlockCompilerTest extends UnitTestCase
 {
     public static function notUniqueIdentifiersThrowAnExceptionDataProvider(): iterable
     {

--- a/Tests/Unit/Definition/Factory/ContentBlockCompilerTest.php
+++ b/Tests/Unit/Definition/Factory/ContentBlockCompilerTest.php
@@ -691,6 +691,64 @@ final class ContentBlockCompilerTest extends UnitTestCase
     }
 
     #[Test]
+    public function linebreaksCanBeIgnoredIfConfiguredExplicitly(): void
+    {
+        $contentBlocks = [
+            [
+                'name' => 'foo/bar',
+                'icon' => [
+                    'iconPath' => '',
+                    'iconProvider' => '',
+                ],
+                'extPath' => 'EXT:example/ContentBlocks/foo',
+                'yaml' => [
+                    'table' => 'tt_content',
+                    'typeField' => 'CType',
+                    'typeName' => 'foo_bar',
+                    'fields' => [
+                        [
+                            'identifier' => 'palette_1',
+                            'type' => 'Palette',
+                            'fields' => [
+                                [
+                                    'identifier' => 'field1',
+                                    'type' => 'Text',
+                                ],
+                                [
+                                    'type' => 'Linebreak',
+                                ],
+                                [
+                                    'identifier' => 'field2',
+                                    'type' => 'Text',
+                                ],
+                            ],
+                        ],
+                        [
+                            'type' => 'Linebreak',
+                            'ignoreIfNotInPalette' => true,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $fieldTypeRegistry = FieldTypeRegistryTestFactory::create();
+        $fieldTypeResolver = new FieldTypeResolver($fieldTypeRegistry);
+        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver);
+        $contentBlockRegistry = new ContentBlockRegistry();
+        foreach ($contentBlocks as $contentBlock) {
+            $contentBlockRegistry->register(LoadedContentBlock::fromArray($contentBlock));
+        }
+        $contentBlockCompiler = new ContentBlockCompiler();
+        $tableDefinitionCollectionFactory = new TableDefinitionCollectionFactory(new NullFrontend('test'), $contentBlockCompiler);
+        $tableDefinitionCollectionFactory->createUncached(
+            $contentBlockRegistry,
+            $fieldTypeRegistry,
+            $simpleTcaSchemaFactory
+        );
+    }
+
+    #[Test]
     public function linebreaksAreOnlyAllowedWithinPalettesInsideCollections(): void
     {
         $contentBlocks = [


### PR DESCRIPTION
so they will be ignored if the 'assertIfNotInPalette' is set to false (default is true). So you can make use of linkebreaks where you want and if the context applies the linebreaks will work otherwise they will be ignored