### PR TITLE
[WIP][BUGFIX] Re-initialize SimpleTcaSchemaFactory after TCA complete

### DIFF
--- a/Classes/Schema/SimpleTcaSchemaFactory.php
+++ b/Classes/Schema/SimpleTcaSchemaFactory.php
@@ -32,9 +32,13 @@ class SimpleTcaSchemaFactory implements SingletonInterface
 
     public function __construct(
         protected FieldTypeResolver $typeResolver,
-        array $tca = null
     ) {
-        $this->tca = $tca ?? $GLOBALS['TCA'] ?? [];
+        $this->initialize($GLOBALS['TCA'] ?? []);
+    }
+
+    public function initialize(array $tca): void
+    {
+        $this->tca = $tca;
         foreach (array_keys($this->tca) as $table) {
             $this->schemas[$table] = $this->build($table);
         }

--- a/Tests/Unit/Generator/TcaGeneratorTest.php
+++ b/Tests/Unit/Generator/TcaGeneratorTest.php
@@ -2089,7 +2089,8 @@ final class TcaGeneratorTest extends UnitTestCase
 
         $fieldTypeRegistry = FieldTypeRegistryTestFactory::create();
         $fieldTypeResolver = new FieldTypeResolver($fieldTypeRegistry);
-        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver, $baseTca);
+        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver);
+        $simpleTcaSchemaFactory->initialize($baseTca);
         $contentBlocks = array_map(fn(array $contentBlock) => LoadedContentBlock::fromArray($contentBlock), $contentBlocks);
         $contentBlockRegistry = new ContentBlockRegistry();
         foreach ($contentBlocks as $contentBlock) {
@@ -2269,7 +2270,8 @@ final class TcaGeneratorTest extends UnitTestCase
 
         $fieldTypeRegistry = FieldTypeRegistryTestFactory::create();
         $fieldTypeResolver = new FieldTypeResolver($fieldTypeRegistry);
-        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver, $baseTca);
+        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver);
+        $simpleTcaSchemaFactory->initialize($baseTca);
         $contentBlocks = array_map(fn(array $contentBlock) => LoadedContentBlock::fromArray($contentBlock), $contentBlocks);
         $contentBlockRegistry = new ContentBlockRegistry();
         foreach ($contentBlocks as $contentBlock) {
@@ -2979,7 +2981,8 @@ final class TcaGeneratorTest extends UnitTestCase
 
         $fieldTypeRegistry = FieldTypeRegistryTestFactory::create();
         $fieldTypeResolver = new FieldTypeResolver($fieldTypeRegistry);
-        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver, $baseTca);
+        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver);
+        $simpleTcaSchemaFactory->initialize($baseTca);
         $contentBlockRegistry = new ContentBlockRegistry();
         foreach ($contentBlocks as $contentBlock) {
             $contentBlockRegistry->register(LoadedContentBlock::fromArray($contentBlock));
@@ -3033,7 +3036,8 @@ final class TcaGeneratorTest extends UnitTestCase
 
         $fieldTypeRegistry = FieldTypeRegistryTestFactory::create();
         $fieldTypeResolver = new FieldTypeResolver($fieldTypeRegistry);
-        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver, $baseTca);
+        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver);
+        $simpleTcaSchemaFactory->initialize($baseTca);
         $contentBlockRegistry = new ContentBlockRegistry();
         $contentBlockRegistry->register($contentBlock);
         $contentBlockCompiler = new ContentBlockCompiler();
@@ -3257,7 +3261,8 @@ final class TcaGeneratorTest extends UnitTestCase
 
         $fieldTypeRegistry = FieldTypeRegistryTestFactory::create();
         $fieldTypeResolver = new FieldTypeResolver($fieldTypeRegistry);
-        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver, $baseTca);
+        $simpleTcaSchemaFactory = new SimpleTcaSchemaFactory($fieldTypeResolver);
+        $simpleTcaSchemaFactory->initialize($baseTca);
         $contentBlockRegistry = new ContentBlockRegistry();
         $contentBlockRegistry->register($contentBlock);
         $contentBlockCompiler = new ContentBlockCompiler();


### PR DESCRIPTION
@todo SqlGenerator builds uncached TableDefinitionCollection with full TCA now. This leads to problems with the type field not being generated anymore for Record Types. We need a
"Base"-SimpleTcaSchemaFactory and a "Full" one in some sort or another.

Fixes: #185