### PR TITLE
[TASK] Hide children in page content fetching process

### DIFF
--- a/Documentation/API/NestedContentElements/Index.rst
+++ b/Documentation/API/NestedContentElements/Index.rst
@@ -5,10 +5,6 @@
 Nested Content Elements
 =======================
 
-..  warning::
-
-    This feature currently does not work with the new PageContentFetching API.
-
 It is possible to nest Content Elements within Content Blocks.
 By default, TYPO3 would render those nested elements within the TYPO3 Page
 Module in the backend and the frontend output. Content Blocks delivers an API
@@ -168,10 +164,11 @@ to prevent fetching any child elements.
 
 ..  note::
 
-    If you do not build upon :typoscript:`styles.content.get`, you need to
-    integrate the logic yourself. The necessary API providing all the columns is
-    available via :php:`TYPO3\CMS\ContentBlocks\UserFunction\ContentWhere->extend`.
-    This can be used to apply the same approach to :php:`TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor`.
+    If you do not build upon :typoscript:`styles.content.get` or the
+    :php-short:`TYPO3\CMS\Frontend\DataProcessing\PageContentFetchingProcessor`,
+    you need to integrate the logic yourself. The necessary API providing all
+    the columns is available via :php:`TYPO3\CMS\ContentBlocks\UserFunction\ContentWhere->extend`.
+    This can be used to apply the same approach to :php-short:`TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor`.
 
     Example:
 

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,10 @@
 	},
 	"require": {
 		"symfony/var-exporter": "^7.0",
-		"typo3/cms-backend": "^13.4",
-		"typo3/cms-core": "^13.4",
-		"typo3/cms-fluid": "^13.4",
-		"typo3/cms-frontend": "^13.4"
+		"typo3/cms-backend": "^13.4.2",
+		"typo3/cms-core": "^13.4.2",
+		"typo3/cms-fluid": "^13.4.2",
+		"typo3/cms-frontend": "^13.4.2"
 	},
 	"replace": {
 		"contentblocks/content-blocks": "*"
@@ -71,14 +71,14 @@
 		"friendsoftypo3/phpstan-typo3": "^0.9.0",
 		"phpstan/phpstan": "^1.10.22",
 		"phpstan/phpstan-phpunit": "^1.3.13",
-		"typo3/cms-extbase": "^13.4",
-		"typo3/cms-extensionmanager": "^13.4",
-		"typo3/cms-filelist": "^13.4",
-		"typo3/cms-install": "^13.4",
-		"typo3/cms-lowlevel": "^13.4",
-		"typo3/cms-rte-ckeditor": "^13.4",
-		"typo3/cms-tstemplate": "^13.4",
-		"typo3/cms-workspaces": "^13.4",
+		"typo3/cms-extbase": "^13.4.2",
+		"typo3/cms-extensionmanager": "^13.4.2",
+		"typo3/cms-filelist": "^13.4.2",
+		"typo3/cms-install": "^13.4.2",
+		"typo3/cms-lowlevel": "^13.4.2",
+		"typo3/cms-rte-ckeditor": "^13.4.2",
+		"typo3/cms-tstemplate": "^13.4.2",
+		"typo3/cms-workspaces": "^13.4.2",
 		"typo3/coding-standards": "^0.8",
 		"typo3/testing-framework": "^9"
 	},

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,7 +11,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '1.0.4',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.4.0-13.4.99',
+            'typo3' => '13.4.2-13.4.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
An event listener is registered for the new
BeforePageContentIsFetchedEvent. This Event will be specially released for TYPO3 13.4.2.

Fixes: #273