### PR TITLE
[FEATURE] Field Type SelectNumber

### DIFF
--- a/Classes/FieldType/SelectNumberFieldType.php
+++ b/Classes/FieldType/SelectNumberFieldType.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\ContentBlocks\FieldType;
+
+/**
+ * @internal Not part of TYPO3's public API.
+ */
+#[FieldType(name: 'SelectNumber', tcaType: 'select')]
+final class SelectNumberFieldType extends AbstractFieldType
+{
+    use WithCommonProperties;
+
+    private string|int $default = '';
+    private bool $readOnly = false;
+    private int $size = 0;
+    private string $authMode = '';
+    private bool $disableNoMatchingValueElement = false;
+    private array $itemGroups = [];
+    private array $items = [];
+    private array $sortItems = [];
+
+    public function createFromArray(array $settings): SelectNumberFieldType
+    {
+        $self = clone $this;
+        $self->setCommonProperties($settings);
+        $default = $settings['default'] ?? $self->default;
+        if (is_string($default) || is_int($default)) {
+            $self->default = $default;
+        }
+        $self->readOnly = (bool)($settings['readOnly'] ?? $self->readOnly);
+        $self->size = (int)($settings['size'] ?? $self->size);
+        $self->authMode = (string)($settings['authMode'] ?? $self->authMode);
+        $self->disableNoMatchingValueElement = (bool)($settings['disableNoMatchingValueElement'] ?? $self->disableNoMatchingValueElement);
+        $self->itemGroups = (array)($settings['itemGroups'] ?? $self->itemGroups);
+        $self->items = (array)($settings['items'] ?? $self->items);
+        foreach ($self->items as $item) {
+            $value = $item['value'] ?? null;
+            if (!is_int($value)) {
+                throw new \InvalidArgumentException(
+                    'Item values for Content Blocks field type "SelectNumber" must be integers. Got "' . $value . '" (' . gettype($value) . ').',
+                    1733310237
+                );
+            }
+        }
+        $self->sortItems = (array)($settings['sortItems'] ?? $self->sortItems);
+
+        return $self;
+    }
+
+    public function getTca(): array
+    {
+        $tca = $this->toTca();
+        $config['type'] = $this->getTcaType();
+        $config['renderType'] = 'selectSingle';
+        if ($this->default !== '') {
+            $config['default'] = $this->default;
+        }
+        if ($this->readOnly) {
+            $config['readOnly'] = true;
+        }
+        if ($this->size > 0) {
+            $config['size'] = $this->size;
+        }
+        if ($this->authMode !== '') {
+            $config['authMode'] = $this->authMode;
+        }
+        if ($this->disableNoMatchingValueElement) {
+            $config['disableNoMatchingValueElement'] = true;
+        }
+        if ($this->itemGroups !== []) {
+            $config['itemGroups'] = $this->itemGroups;
+        }
+        $config['items'] = $this->items;
+        if ($this->sortItems !== []) {
+            $config['sortItems'] = $this->sortItems;
+        }
+        $tca['config'] = array_replace($tca['config'] ?? [], $config);
+        return $tca;
+    }
+
+    public function getNonOverridableOptions(): array
+    {
+        return ['renderType', 'items'];
+    }
+}

--- a/Documentation/ChangeLog/1.1/Index.rst
+++ b/Documentation/ChangeLog/1.1/Index.rst
@@ -5,6 +5,8 @@
 1.1
 ===
 
+..  contents::
+
 Features
 ========
 
@@ -78,6 +80,25 @@ else, you can override the default folder by providing the option
     :caption: You can use an alternative skeleton path
 
     vendor/bin/typo3 make:content-block --skeleton-path="my-alternative-skeleton-path"
+
+Field Type SelectNumber
+-----------------------
+
+A new field type :ref:`SelectNumber <field_type_select-number>` is added. This
+new type allows to have a select field with exclusively integer values. The
+database column will also have type :sql:`int`, which saves precious row size.
+
+..  code-block:: yaml
+
+    name: example/select-number
+    fields:
+      - identifier: select_number
+        type: SelectNumber
+        items:
+          - label: 'The first'
+            value: 1
+          - label: 'The second'
+            value: 2
 
 Deprecations
 ============

--- a/Documentation/YamlReference/FieldTypes/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Index.rst
@@ -22,6 +22,7 @@ Simple Field Types:
 *  :ref:`Number <field_type_number>`
 *  :ref:`Password <field_type_password>`
 *  :ref:`Radio <field_type_radio>`
+*  :ref:`SelectNumber <field_type_select-number>`
 *  :ref:`Slug <field_type_slug>`
 *  :ref:`Text <field_type_text>`
 *  :ref:`Textarea <field_type_textarea>`

--- a/Documentation/YamlReference/FieldTypes/SelectNumber/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/SelectNumber/Index.rst
@@ -18,17 +18,17 @@ Settings
     :default:
     :required:
 
-.. confval:: default
-   :name: select-number-default
-   :required: false
-   :type: integer
+..  confval:: default
+    :name: select-number-default
+    :required: false
+    :type: integer
 
    Default value set if a new record is created.
 
-.. confval:: items
-   :name: select-number-items
-   :required: false
-   :type: array
+..  confval:: items
+    :name: select-number-items
+    :required: false
+    :type: array
 
    Contains the elements for the selector box. Each item is an array. An item
    consists of a :yaml:`label` and a :yaml:`value`.
@@ -103,7 +103,7 @@ Example
 Minimal
 -------
 
-.. code-block:: yaml
+..  code-block:: yaml
 
     name: example/select-number
     fields:
@@ -122,10 +122,10 @@ Advanced / use case
 
 Select with icons:
 
-.. code-block:: yaml
+..  code-block:: yaml
 
-   name: example/select-number
-   fields:
+    name: example/select-number
+    fields:
      - identifier: select_number_icons
        type: SelectNumber
        fieldWizard:

--- a/Documentation/YamlReference/FieldTypes/SelectNumber/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/SelectNumber/Index.rst
@@ -1,0 +1,144 @@
+.. include:: /Includes.rst.txt
+.. _field_type_select-number:
+
+============
+SelectNumber
+============
+
+The :yaml:`SelectNumber` type generates a simple select field, which only allows
+numbers / integers.
+
+Settings
+========
+
+..  confval-menu::
+    :name: confval-select-number-options
+    :display: table
+    :type:
+    :default:
+    :required:
+
+.. confval:: default
+   :name: select-number-default
+   :required: false
+   :type: integer
+
+   Default value set if a new record is created.
+
+.. confval:: items
+   :name: select-number-items
+   :required: false
+   :type: array
+
+   Contains the elements for the selector box. Each item is an array. An item
+   consists of a :yaml:`label` and a :yaml:`value`.
+
+   Example:
+
+   .. code-block:: yaml
+
+      items:
+        - label: 'The first'
+          value: 1
+        - label: 'The second'
+          value: 2
+        - label: 'The third'
+          value: 3
+
+   .. tip::
+
+      You can omit the label, if you have the translation already in your
+      labels.xlf file.
+
+      .. code-block:: yaml
+
+          items:
+            - value: 1
+            - value: 2
+            - value: 3
+
+   .. tip::
+
+      You can also use icons so they are displayed in the backend.
+      See :ref:`select-number-icons` for a full example.
+
+      .. code-block:: yaml
+
+          items:
+            - value: 1
+              icon: content-beside-text-img-left
+            - value: 2
+              icon: content-beside-text-img-right
+            - value: 3
+              icon: content-beside-text-img-above-center
+
+      For this you need the following setting according to the :ref:`TCA documentation <t3tca:tca_property_fieldWizard_selectIcons>`.
+
+      .. code-block:: yaml
+
+          fieldWizard:
+            selectIcons:
+              disabled: false
+
+   XLF translation keys for items have the following convention:
+
+   .. code-block:: xml
+
+        <body>
+            <trans-unit id="FIELD_IDENTIFIER.items.1.label">
+                <source>Label for item with value one</source>
+            </trans-unit>
+            <trans-unit id="FIELD_IDENTIFIER.items.2.label">
+                <source>Label for item with value two</source>
+            </trans-unit>
+            <trans-unit id="FIELD_IDENTIFIER.items.VALUE.label">
+                <source>Label for item with value VALUE</source>
+            </trans-unit>
+        </body>
+
+
+Example
+=======
+
+Minimal
+-------
+
+.. code-block:: yaml
+
+    name: example/select-number
+    fields:
+      - identifier: select_number
+        type: SelectNumber
+        items:
+          - label: 'The first'
+            value: 1
+          - label: 'The second'
+            value: 2
+
+Advanced / use case
+-------------------
+
+..  _select-number-icons:
+
+Select with icons:
+
+.. code-block:: yaml
+
+   name: example/select-number
+   fields:
+     - identifier: select_number_icons
+       type: SelectNumber
+       fieldWizard:
+         selectIcons:
+           disabled: false
+       default: 2
+       items:
+         - label: 'Image beside text (left)'
+           value: 1
+           icon: content-beside-text-img-left
+         - label: 'Image beside text (right)'
+           value: 2
+           icon: content-beside-text-img-right
+         - label: 'Image above text (center)'
+           value: 3
+           icon: content-beside-text-img-above-cent

--- a/Tests/Unit/FieldTypes/SelectNumberFieldTypeTest.php
+++ b/Tests/Unit/FieldTypes/SelectNumberFieldTypeTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\ContentBlocks\Tests\Unit\FieldTypes;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\ContentBlocks\Tests\Unit\Fixtures\FieldTypeRegistryTestFactory;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class SelectNumberFieldTypeTest extends UnitTestCase
+{
+    public static function getTcaReturnsExpectedTcaDataProvider(): iterable
+    {
+        yield 'truthy values' => [
+            'config' => [
+                'label' => 'foo',
+                'description' => 'foo',
+                'displayCond' => [
+                    'foo' => 'bar',
+                ],
+                'l10n_display' => 'foo',
+                'l10n_mode' => 'foo',
+                'onChange' => 'foo',
+                'exclude' => true,
+                'non_available_field' => 'foo',
+                'default' => 1,
+                'readOnly' => 1,
+                'size' => 1,
+                'authMode' => 'foo',
+                'disableNoMatchingValueElement' => 1,
+                'itemGroups' => [
+                    'foo' => 'bar',
+                ],
+                'items' => [
+                    ['label' => 'Foo', 'value' => 1],
+                ],
+                'sortItems' => [
+                    'foo' => 'bar',
+                ],
+                'dbFieldLength' => 10,
+            ],
+            'expectedTca' => [
+                'label' => 'foo',
+                'description' => 'foo',
+                'displayCond' => [
+                    'foo' => 'bar',
+                ],
+                'l10n_display' => 'foo',
+                'l10n_mode' => 'foo',
+                'onChange' => 'foo',
+                'exclude' => true,
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectSingle',
+                    'default' => 1,
+                    'readOnly' => true,
+                    'size' => 1,
+                    'authMode' => 'foo',
+                    'disableNoMatchingValueElement' => true,
+                    'itemGroups' => [
+                        'foo' => 'bar',
+                    ],
+                    'items' => [
+                        ['label' => 'Foo', 'value' => 1],
+                    ],
+                    'sortItems' => [
+                        'foo' => 'bar',
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'falsy values' => [
+            'config' => [
+                'label' => '',
+                'description' => null,
+                'displayCond' => [],
+                'l10n_display' => '',
+                'l10n_mode' => '',
+                'onChange' => '',
+                'exclude' => false,
+                'non_available_field' => 'foo',
+                'default' => '',
+                'readOnly' => 0,
+                'size' => 0,
+                'allowNonIdValues' => 0,
+                'authMode' => '',
+                'disableNoMatchingValueElement' => 0,
+                'itemGroups' => [],
+                'items' => [],
+                'sortItems' => [],
+            ],
+            'expectedTca' => [
+                'config' => [
+                    'type' => 'select',
+                    'renderType' => 'selectSingle',
+                    'items' => [],
+                ],
+            ],
+        ];
+    }
+
+    #[DataProvider('getTcaReturnsExpectedTcaDataProvider')]
+    #[Test]
+    public function getTcaReturnsExpectedTca(array $config, array $expectedTca): void
+    {
+        $fieldTypeRegistry = FieldTypeRegistryTestFactory::create();
+        $fieldType = $fieldTypeRegistry->get('SelectNumber');
+        $fieldConfiguration = $fieldType->createFromArray($config);
+
+        self::assertSame($expectedTca, $fieldConfiguration->getTca());
+    }
+}

--- a/Tests/Unit/Fixtures/FieldTypeRegistryTestFactory.php
+++ b/Tests/Unit/Fixtures/FieldTypeRegistryTestFactory.php
@@ -41,6 +41,7 @@ use TYPO3\CMS\ContentBlocks\FieldType\PasswordFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\RadioFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\RelationFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SelectFieldType;
+use TYPO3\CMS\ContentBlocks\FieldType\SelectNumberFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\SlugFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TabFieldType;
 use TYPO3\CMS\ContentBlocks\FieldType\TextareaFieldType;
@@ -77,6 +78,7 @@ class FieldTypeRegistryTestFactory
             new TextFieldType(),
             new UuidFieldType(),
             new PassFieldType(),
+            new SelectNumberFieldType(),
         ];
         $keyedFieldTypes = [];
         foreach ($fieldTypes as $fieldType) {


### PR DESCRIPTION
Content Blocks now has a field type "SelectNumber". This is a more specific version of type "Select" which only allows integer values. The benefit of this type is that the database column is created as type "int", thus saving precious db row size.

Fixes: #311