### PR TITLE
Added note about identifier uniqueness for collection fields

### DIFF
--- a/Documentation/YamlReference/FieldTypes/Index.rst
+++ b/Documentation/YamlReference/FieldTypes/Index.rst
@@ -89,6 +89,10 @@ Field options, which can be defined inside the :yaml:`fields` array.
    The field's identifier has to be unique within a Content Block. Exception is
    within a collections' field array, as this starts a new scope.
 
+   Additionally, the identifier for fields of the type collection has to be unique 
+   for all Content Blocks within a TYPO3 website, if those fields share the same
+   foreign table.
+
    .. warning::
 
       Avoid using dashes "-" inside your identifiers. They are not guaranteed to


### PR DESCRIPTION
It is important to note, that it should be avoided to have multiple content blocks, which all have a field of the type `collection` and which all share the same table and which all have the same identifier.

If different content blocks use the same identifier for collection fields that use the same `foreign_table` (e.g. `tt_content`), it occurs, that collection children get mixed up.