### PR TITLE
[FIX] Deprecation Warning in ContentBlockBuilder

### DIFF
--- a/Classes/Builder/ContentBlockBuilder.php
+++ b/Classes/Builder/ContentBlockBuilder.php
@@ -47,7 +47,7 @@ readonly class ContentBlockBuilder
     /**
      * Writes a Content Block to file system.
      */
-    public function create(LoadedContentBlock $contentBlock, string $skeletonPath = null): void
+    public function create(LoadedContentBlock $contentBlock, ?string $skeletonPath = null): void
     {
         $name = $contentBlock->getPackage();
         $extPath = $contentBlock->getExtPath();


### PR DESCRIPTION
As of PHP 8.4 implicitly declaring function parameters nullable is deprecated.

Explicitly nullable types have been available since PHP 7.1

See: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated