### PR TITLE
Add new command functional test for extension:setup to reproduce cache issues from Version 1.3.2

### DIFF
--- a/Tests/Functional/Command/ContentBlockCommandTest.php
+++ b/Tests/Functional/Command/ContentBlockCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+namespace TYPO3\CMS\ContentBlocks\Tests\Functional\Frontend;
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
+use TYPO3\CMS\Core\Command\SetupExtensionsCommand;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+final class ContentBlockCommandTest extends FunctionalTestCase
+{
+
+    use SiteBasedTestTrait;
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/content_blocks/Tests/Fixtures/Extensions/test_content_blocks_b',
+        'typo3conf/ext/content_blocks/Tests/Fixtures/Extensions/test_content_blocks_c',
+        'typo3conf/ext/content_blocks',
+    ];
+
+    protected const LANGUAGE_PRESETS = [
+        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8'],
+    ];
+    protected const ROOT_PAGE_ID = 1;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    #[Test]
+    public function extensionSetupCacheTest(): void
+    {
+        // Warmup cache with internal call
+        $this->importCSVDataSet(__DIR__ . '/../Frontend/Fixtures/DataSet/base.csv');
+        $this->writeSiteConfiguration(
+            'fluid_template',
+            $this->buildSiteConfiguration(self::ROOT_PAGE_ID, '/'),
+        );
+
+        $this->importCSVDataSet(__DIR__ . '/../Frontend/Fixtures/DataSet/frontend_simple_element.csv');
+        $this->setUpFrontendRootPage(
+            self::ROOT_PAGE_ID,
+            [
+                'EXT:content_blocks/Tests/Functional/Frontend/Fixtures/frontend.typoscript',
+            ]
+        );
+        $response = $this->executeFrontendSubRequest((new InternalRequest())->withPageId(self::ROOT_PAGE_ID));
+        $html = (string) $response->getBody();
+        self::assertStringContainsString('HeaderSimple', $html);
+        #echo $html;
+        // Run extension:setup
+        Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class);
+
+        // Use CommandTester to execute the command
+        $commandTester = new CommandTester($this->get(SetupExtensionsCommand::class));
+        $commandTester->execute([]);
+
+        print_r($commandTester->getDisplay());
+
+        self::assertEquals(0, $commandTester->getStatusCode());
+    }
+}

--- a/Tests/Functional/Command/ContentBlockCommandTest.php
+++ b/Tests/Functional/Command/ContentBlockCommandTest.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * The TYPO3 project - inspiring people to share!
  */
 
-namespace TYPO3\CMS\ContentBlocks\Tests\Functional\Frontend;
+namespace TYPO3\CMS\ContentBlocks\Tests\Functional\Command;
 
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -32,11 +32,6 @@ final class ContentBlockCommandTest extends FunctionalTestCase
         'typo3conf/ext/content_blocks/Tests/Fixtures/Extensions/test_content_blocks_c',
         'typo3conf/ext/content_blocks',
     ];
-
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
 
     #[Test]
     public function extensionSetupCacheTest(): void

--- a/Tests/Functional/Command/ContentBlockCommandTest.php
+++ b/Tests/Functional/Command/ContentBlockCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*
@@ -13,7 +14,8 @@ declare(strict_types=1);
  *
  * The TYPO3 project - inspiring people to share!
  */
-namespace TYPO3\CMS\ContentBlocks\Tests\Functional\Frontend;
+
+namespace TYPO3\CMS\ContentBlocks\Tests\Functional\Command;
 
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -26,7 +28,6 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 final class ContentBlockCommandTest extends FunctionalTestCase
 {
-
     use SiteBasedTestTrait;
 
     protected array $testExtensionsToLoad = [
@@ -63,9 +64,9 @@ final class ContentBlockCommandTest extends FunctionalTestCase
             ]
         );
         $response = $this->executeFrontendSubRequest((new InternalRequest())->withPageId(self::ROOT_PAGE_ID));
-        $html = (string) $response->getBody();
+        $html = (string)$response->getBody();
         self::assertStringContainsString('HeaderSimple', $html);
-        #echo $html;
+
         // Run extension:setup
         Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class);
 

--- a/Tests/Functional/Command/ContentBlockCommandTest.php
+++ b/Tests/Functional/Command/ContentBlockCommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*
@@ -13,32 +14,24 @@ declare(strict_types=1);
  *
  * The TYPO3 project - inspiring people to share!
  */
+
 namespace TYPO3\CMS\ContentBlocks\Tests\Functional\Frontend;
 
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Tester\CommandTester;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
+use TYPO3\CMS\Core\Command\CacheWarmupCommand;
 use TYPO3\CMS\Core\Command\SetupExtensionsCommand;
 use TYPO3\CMS\Core\Core\Bootstrap;
-use TYPO3\CMS\Core\Tests\Functional\SiteHandling\SiteBasedTestTrait;
-use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 final class ContentBlockCommandTest extends FunctionalTestCase
 {
-
-    use SiteBasedTestTrait;
-
     protected array $testExtensionsToLoad = [
         'typo3conf/ext/content_blocks/Tests/Fixtures/Extensions/test_content_blocks_b',
         'typo3conf/ext/content_blocks/Tests/Fixtures/Extensions/test_content_blocks_c',
         'typo3conf/ext/content_blocks',
     ];
-
-    protected const LANGUAGE_PRESETS = [
-        'EN' => ['id' => 0, 'title' => 'English', 'locale' => 'en_US.UTF8'],
-    ];
-    protected const ROOT_PAGE_ID = 1;
 
     public function setUp(): void
     {
@@ -48,33 +41,19 @@ final class ContentBlockCommandTest extends FunctionalTestCase
     #[Test]
     public function extensionSetupCacheTest(): void
     {
-        // Warmup cache with internal call
-        $this->importCSVDataSet(__DIR__ . '/../Frontend/Fixtures/DataSet/base.csv');
-        $this->writeSiteConfiguration(
-            'fluid_template',
-            $this->buildSiteConfiguration(self::ROOT_PAGE_ID, '/'),
-        );
+        // Warmup the cache to reproduce cache issue
+        $commandTesterCacheWarmup = new CommandTester($this->get(CacheWarmupCommand::class));
+        $commandTesterCacheWarmup->execute([]);
 
-        $this->importCSVDataSet(__DIR__ . '/../Frontend/Fixtures/DataSet/frontend_simple_element.csv');
-        $this->setUpFrontendRootPage(
-            self::ROOT_PAGE_ID,
-            [
-                'EXT:content_blocks/Tests/Functional/Frontend/Fixtures/frontend.typoscript',
-            ]
-        );
-        $response = $this->executeFrontendSubRequest((new InternalRequest())->withPageId(self::ROOT_PAGE_ID));
-        $html = (string) $response->getBody();
-        self::assertStringContainsString('HeaderSimple', $html);
-        #echo $html;
+        self::assertEquals(0, $commandTesterCacheWarmup->getStatusCode());
+
+        $this->setUp();
+
         // Run extension:setup
         Bootstrap::initializeBackendUser(CommandLineUserAuthentication::class);
+        $commandTesterSetupExtension = new CommandTester($this->get(SetupExtensionsCommand::class));
+        $commandTesterSetupExtension->execute([]);
 
-        // Use CommandTester to execute the command
-        $commandTester = new CommandTester($this->get(SetupExtensionsCommand::class));
-        $commandTester->execute([]);
-
-        print_r($commandTester->getDisplay());
-
-        self::assertEquals(0, $commandTester->getStatusCode());
+        self::assertEquals(0, $commandTesterSetupExtension->getStatusCode());
     }
 }


### PR DESCRIPTION
Standalone call:

Build/Scripts/runTests.sh -s functional -e Tests/Functional/Command/ContentBlockCommandTest.php -v