### PR TITLE
[BUGFIX] Fix page-type-specific layoutRootPath

### DIFF
--- a/Classes/Backend/Preview/PageLayout.php
+++ b/Classes/Backend/Preview/PageLayout.php
@@ -116,7 +116,7 @@ readonly class PageLayout
     protected function getContentBlocksLayoutRootPaths(string $contentBlockPrivatePath, int $pageUid): array
     {
         $layoutRootPaths = $this->rootPathsSettings->getContentBlocksLayoutRootPaths($pageUid);
-        $layoutRootPaths[] = $contentBlockPrivatePath . '/layouts';
+        $layoutRootPaths[] = $contentBlockPrivatePath . '/layouts/';
         return $layoutRootPaths;
     }
 


### PR DESCRIPTION
Function `PageLayout::getContentBlocksLayoutRootPaths()` returns the type-specific layout path without a trailing slash.