### PR TITLE
[BUGFIX] Respect numeric key order in RootPathsSettings

### DIFF
--- a/Classes/Backend/Preview/RootPathsSettings.php
+++ b/Classes/Backend/Preview/RootPathsSettings.php
@@ -33,7 +33,7 @@ class RootPathsSettings
         $partialRootPaths = [];
         foreach ($this->getContentBlocksPageTsPartialRootPaths($pageUid) as $key => $rootPath) {
             if (MathUtility::canBeInterpretedAsInteger($key)) {
-                $partialRootPaths[(int) $key] = $rootPath;
+                $partialRootPaths[(int)$key] = $rootPath;
             } else {
                 $partialRootPaths[] = $rootPath;
             }
@@ -49,7 +49,7 @@ class RootPathsSettings
         $layoutRootPaths = [];
         foreach ($this->getContentBlocksPageTsLayoutRootPaths($pageUid) as $key => $rootPath) {
             if (MathUtility::canBeInterpretedAsInteger($key)) {
-                $layoutRootPaths[(int) $key] = $rootPath;
+                $layoutRootPaths[(int)$key] = $rootPath;
             } else {
                 $layoutRootPaths[] = $rootPath;
             }

--- a/Classes/Backend/Preview/RootPathsSettings.php
+++ b/Classes/Backend/Preview/RootPathsSettings.php
@@ -29,10 +29,8 @@ class RootPathsSettings
      */
     public function getContentBlocksPartialRootPaths(int $pageUid): array
     {
-        $partialRootPaths = [];
-        foreach ($this->getContentBlocksPageTsPartialRootPaths($pageUid) as $key => $rootPath) {
-            $partialRootPaths[$key] = $rootPath;
-        }
+        $partialRootPaths = $this->getContentBlocksPageTsPartialRootPaths($pageUid);
+        $partialRootPaths = $this->sortRootPaths($partialRootPaths);
         return $partialRootPaths;
     }
 
@@ -41,15 +39,13 @@ class RootPathsSettings
      */
     public function getContentBlocksLayoutRootPaths(int $pageUid): array
     {
-        $layoutRootPaths = [];
-        foreach ($this->getContentBlocksPageTsLayoutRootPaths($pageUid) as $key => $rootPath) {
-            $layoutRootPaths[$key] = $rootPath;
-        }
+        $layoutRootPaths = $this->getContentBlocksPageTsLayoutRootPaths($pageUid);
+        $layoutRootPaths = $this->sortRootPaths($layoutRootPaths);
         return $layoutRootPaths;
     }
 
     /**
-     * @return string[]
+     * @return array<int, string>
      */
     protected function getContentBlocksPageTsPartialRootPaths(int $pageUid): array
     {
@@ -59,7 +55,7 @@ class RootPathsSettings
     }
 
     /**
-     * @return string[]
+     * @return array<int, string>
      */
     protected function getContentBlocksPageTsLayoutRootPaths(int $pageUid): array
     {
@@ -73,5 +69,15 @@ class RootPathsSettings
         $pageTsConfig = BackendUtility::getPagesTSconfig($pageUid);
         $contentBlocksConfig = $pageTsConfig['tx_content_blocks.'] ?? [];
         return $contentBlocksConfig;
+    }
+
+    /**
+     * @param array<int, string> $rootPaths
+     * @return array<int, string>
+     */
+    protected function sortRootPaths(array $rootPaths): array
+    {
+        ksort($rootPaths);
+        return $rootPaths;
     }
 }

--- a/Classes/Backend/Preview/RootPathsSettings.php
+++ b/Classes/Backend/Preview/RootPathsSettings.php
@@ -18,7 +18,6 @@ declare(strict_types=1);
 namespace TYPO3\CMS\ContentBlocks\Backend\Preview;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
-use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
  * @internal Not part of TYPO3's public API.
@@ -32,11 +31,7 @@ class RootPathsSettings
     {
         $partialRootPaths = [];
         foreach ($this->getContentBlocksPageTsPartialRootPaths($pageUid) as $key => $rootPath) {
-            if (MathUtility::canBeInterpretedAsInteger($key)) {
-                $partialRootPaths[(int)$key] = $rootPath;
-            } else {
-                $partialRootPaths[] = $rootPath;
-            }
+            $partialRootPaths[$key] = $rootPath;
         }
         return $partialRootPaths;
     }
@@ -48,11 +43,7 @@ class RootPathsSettings
     {
         $layoutRootPaths = [];
         foreach ($this->getContentBlocksPageTsLayoutRootPaths($pageUid) as $key => $rootPath) {
-            if (MathUtility::canBeInterpretedAsInteger($key)) {
-                $layoutRootPaths[(int)$key] = $rootPath;
-            } else {
-                $layoutRootPaths[] = $rootPath;
-            }
+            $layoutRootPaths[$key] = $rootPath;
         }
         return $layoutRootPaths;
     }

--- a/Classes/Backend/Preview/RootPathsSettings.php
+++ b/Classes/Backend/Preview/RootPathsSettings.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace TYPO3\CMS\ContentBlocks\Backend\Preview;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 
 /**
  * @internal Not part of TYPO3's public API.
@@ -30,8 +31,12 @@ class RootPathsSettings
     public function getContentBlocksPartialRootPaths(int $pageUid): array
     {
         $partialRootPaths = [];
-        foreach ($this->getContentBlocksPageTsPartialRootPaths($pageUid) as $rootPath) {
-            $partialRootPaths[] = $rootPath;
+        foreach ($this->getContentBlocksPageTsPartialRootPaths($pageUid) as $key => $rootPath) {
+            if (MathUtility::canBeInterpretedAsInteger($key)) {
+                $partialRootPaths[(int) $key] = $rootPath;
+            } else {
+                $partialRootPaths[] = $rootPath;
+            }
         }
         return $partialRootPaths;
     }
@@ -42,8 +47,12 @@ class RootPathsSettings
     public function getContentBlocksLayoutRootPaths(int $pageUid): array
     {
         $layoutRootPaths = [];
-        foreach ($this->getContentBlocksPageTsLayoutRootPaths($pageUid) as $rootPath) {
-            $layoutRootPaths[] = $rootPath;
+        foreach ($this->getContentBlocksPageTsLayoutRootPaths($pageUid) as $key => $rootPath) {
+            if (MathUtility::canBeInterpretedAsInteger($key)) {
+                $layoutRootPaths[(int) $key] = $rootPath;
+            } else {
+                $layoutRootPaths[] = $rootPath;
+            }
         }
         return $layoutRootPaths;
     }


### PR DESCRIPTION
Prevent `RootPathsSettings::class` from stripping numeric key order used in `tx_content_blocks.view.layoutRootPaths` and `tx_content_blocks.view.partialRootPaths` Page TSconfig settings.

Resolves: #411