### PR TITLE
[BUGFIX] fix exception "Undefined global variable $TCA" when loading …

### DIFF
--- a/Classes/Schema/SimpleTcaSchemaFactory.php
+++ b/Classes/Schema/SimpleTcaSchemaFactory.php
@@ -133,8 +133,10 @@ class SimpleTcaSchemaFactory
         $scopedReturnRequire = static function (string $filename): mixed {
             return require $filename;
         };
+        // Backup the original TCA in case it is already set.
+        $backupTca = $GLOBALS['TCA'] ?? null;
         // First load "full table" files from Configuration/TCA
-        $tca = [];
+        $GLOBALS['TCA'] = [];
         $activePackages = $this->packageManager->getActivePackages();
         foreach ($activePackages as $package) {
             try {
@@ -147,9 +149,15 @@ class SimpleTcaSchemaFactory
                 $tcaOfTable = $scopedReturnRequire($fileInfo->getPathname());
                 if (is_array($tcaOfTable)) {
                     $tcaTableName = substr($fileInfo->getBasename(), 0, -4);
-                    $tca[$tcaTableName] = $tcaOfTable;
+                    $GLOBALS['TCA'][$tcaTableName] = $tcaOfTable;
                 }
             }
+        }
+        $tca = $GLOBALS['TCA'];
+        if ($backupTca) {
+            $GLOBALS['TCA'] = $backupTca;
+        } else {
+            unset($GLOBALS['TCA']);
         }
         return $tca;
     }


### PR DESCRIPTION
**Describe the bug**

After updating to content-blocks v1.3.11 i got the following exception when calling cache:flush:

`PHP Warning: Undefined global variable $TCA in /var/www/html/vendor/georgringer/news/Configuration/TCA/tx_news_domain_model_news.php line 347 `                                                                                                        
                                                                                                                              
```
Exception trace:
#0 ()
   vendor/typo3/cms-core/Classes/Error/ErrorHandler.php:141
#1 TYPO3\CMS\Core\Error\ErrorHandler->handleError()
   vendor/georgringer/news/Configuration/TCA/tx_news_domain_model_news.php:347
#2 require()
   vendor/friendsoftypo3/content-blocks/Classes/Schema/SimpleTcaSchemaFactory.php:134
#3 TYPO3\CMS\ContentBlocks\Schema\SimpleTcaSchemaFactory::{closure:TYPO3\CMS\ContentBlocks\Schema\SimpleTcaSchemaFactory::loadConfigurationTcaFiles():133}()
   vendor/friendsoftypo3/content-blocks/Classes/Schema/SimpleTcaSchemaFactory.php:147
#4 TYPO3\CMS\ContentBlocks\Schema\SimpleTcaSchemaFactory->loadConfigurationTcaFiles()
   vendor/friendsoftypo3/content-blocks/Classes/Schema/SimpleTcaSchemaFactory.php:51
#5 TYPO3\CMS\ContentBlocks\Schema\SimpleTcaSchemaFactory->__construct()
   vendor/typo3/cms-core/Classes/Utility/GeneralUtility.php:2900
```

The TCA file tx_news_domain_model_news.php at line 347 contains the code:

`'label' => $GLOBALS['TCA']['pages']['columns']['keywords']['label'],`

**To Reproduce**
Steps to reproduce the behavior:
1. Install EXT:news
2. Execute `./vendor/bin/typo3 cache:flush -vvv`


**TYPO3 Version**
13.4.17

**Content Blocks Version:**
v1.3.11

**Additional context**

The original function \TYPO3\CMS\Core\Configuration\Tca\TcaFactory::loadConfigurationTcaFiles defines `$GLOBALS['TCA'] = [];`

In \TYPO3\CMS\ContentBlocks\Schema\SimpleTcaSchemaFactory::loadConfigurationTcaFiles this has been changed to `$tca = [];`

I assume this was done to prevent overriding $GLOBALS['TCA'] in case it is defined at this stage.

In my pull request the value of `$GLOBALS['TCA']` is backed up if defined and then restored at the end of the function if necessary.
