### PR TITLE
[BUGFIX] Add missing option "multiple" for type Select

### DIFF
--- a/Classes/FieldType/SelectFieldType.php
+++ b/Classes/FieldType/SelectFieldType.php
@@ -51,6 +51,9 @@ final class SelectFieldType extends AbstractFieldType
     private array $items = [];
     private array $sortItems = [];
 
+    // Only for renderType="selectMultipleSideBySide"
+    private bool $multiple = false;
+
     // Only for renderType="selectCheckBox"
     private array $appearance = [];
 
@@ -90,6 +93,7 @@ final class SelectFieldType extends AbstractFieldType
         $self->itemGroups = (array)($settings['itemGroups'] ?? $self->itemGroups);
         $self->items = (array)($settings['items'] ?? $self->items);
         $self->sortItems = (array)($settings['sortItems'] ?? $self->sortItems);
+        $self->multiple = (bool)($settings['multiple'] ?? $self->multiple);
         $self->appearance = (array)($settings['appearance'] ?? $self->appearance);
         $self->treeConfig = (array)($settings['treeConfig'] ?? $self->treeConfig);
         $self->relationship = (string)($settings['relationship'] ?? $self->relationship);
@@ -179,6 +183,9 @@ final class SelectFieldType extends AbstractFieldType
         $config['items'] = $this->items;
         if ($this->sortItems !== []) {
             $config['sortItems'] = $this->sortItems;
+        }
+        if ($this->multiple) {
+            $config['multiple'] = true;
         }
         if ($this->appearance !== []) {
             $config['appearance'] = $this->appearance;

--- a/Classes/Generator/TcaGenerator.php
+++ b/Classes/Generator/TcaGenerator.php
@@ -440,6 +440,7 @@ readonly class TcaGenerator
             'l10n_mode',
             'dbFieldLength',
             'items',
+            'multiple',
         ];
         $fieldNonOverridableOptions = [];
         // @todo experimental. Could be added as interface method later.

--- a/Tests/Unit/FieldTypes/SelectFieldTypeTest.php
+++ b/Tests/Unit/FieldTypes/SelectFieldTypeTest.php
@@ -73,6 +73,7 @@ final class SelectFieldTypeTest extends UnitTestCase
                 'sortItems' => [
                     'foo' => 'bar',
                 ],
+                'multiple' => 1,
                 'appearance' => [
                     'foo' => 'bar',
                 ],
@@ -131,6 +132,7 @@ final class SelectFieldTypeTest extends UnitTestCase
                     'sortItems' => [
                         'foo' => 'bar',
                     ],
+                    'multiple' => true,
                     'appearance' => [
                         'foo' => 'bar',
                     ],
@@ -180,6 +182,7 @@ final class SelectFieldTypeTest extends UnitTestCase
                 'itemGroups' => [],
                 'items' => [],
                 'sortItems' => [],
+                'multiple' => 0,
                 'appearance' => [],
                 'treeConfig' => [],
                 'dbFieldLength' => 0,


### PR DESCRIPTION
Also exclude it from overrides, as it is important for DB schema.