### PR TITLE
Add Unit Test for file with relationship oneToOne and fix lazy load.

### DIFF
--- a/Classes/DataProcessing/ContentBlockDataDecorator.php
+++ b/Classes/DataProcessing/ContentBlockDataDecorator.php
@@ -29,6 +29,7 @@ use TYPO3\CMS\Core\Domain\Record;
 use TYPO3\CMS\Core\Domain\RecordInterface;
 use TYPO3\CMS\Core\Domain\RecordPropertyClosure;
 use TYPO3\CMS\Core\Resource\Collection\LazyFileReferenceCollection;
+use TYPO3\CMS\Core\Resource\FileReference;
 
 /**
  * @internal Not part of TYPO3's public API.
@@ -124,7 +125,7 @@ final class ContentBlockDataDecorator
         }
         // Relation field type, load lazily.
         $recordPropertyClosure = new RecordPropertyClosure(
-            function () use ($resolvedRelation, $tcaFieldDefinition, $depth, $context): ContentBlockData|LazyRecordCollection|LazyFileReferenceCollection|null {
+            function () use ($resolvedRelation, $tcaFieldDefinition, $depth, $context): ContentBlockData|LazyRecordCollection|LazyFileReferenceCollection|FileReference|null {
                 $resolvedField = $resolvedRelation->record->get($tcaFieldDefinition->uniqueIdentifier);
                 $resolvedField = $this->handleRelation(
                     $resolvedField,
@@ -187,14 +188,17 @@ final class ContentBlockDataDecorator
     }
 
     private function handleRelation(
-        RecordInterface|LazyRecordCollection|LazyFileReferenceCollection|null $resolvedField,
+        RecordInterface|LazyRecordCollection|LazyFileReferenceCollection|FileReference|null $resolvedField,
         int $depth,
         ?PageLayoutContext $context = null,
-    ): ContentBlockData|LazyRecordCollection|LazyFileReferenceCollection|null {
+    ): ContentBlockData|LazyRecordCollection|LazyFileReferenceCollection|FileReference|null {
         if ($resolvedField === null) {
             return null;
         }
         if ($resolvedField instanceof LazyFileReferenceCollection) {
+            return $resolvedField;
+        }
+        if ($resolvedField instanceof FileReference) {
             return $resolvedField;
         }
         if ($resolvedField instanceof LazyRecordCollection) {

--- a/Tests/Fixtures/Extensions/test_content_blocks_b/ContentBlocks/ContentElements/content-element-b/config.yaml
+++ b/Tests/Fixtures/Extensions/test_content_blocks_b/ContentBlocks/ContentElements/content-element-b/config.yaml
@@ -3,6 +3,9 @@ name: typo3tests/content-element-b
 fields:
   - identifier: image
     useExistingField: true
+  - identifier: image_one_to_one
+    type: File
+    relationship: oneToOne
   - identifier: collection
     type: Collection
     fields:

--- a/Tests/Fixtures/Extensions/test_content_blocks_b/ContentBlocks/ContentElements/content-element-b/templates/frontend.html
+++ b/Tests/Fixtures/Extensions/test_content_blocks_b/ContentBlocks/ContentElements/content-element-b/templates/frontend.html
@@ -29,7 +29,9 @@
 <f:for each="{data.image}" as="image">
     image:{image.name}
 </f:for>
-
+<f:if condition="{data.image_one_to_one}">
+    image_one_to_one:{data.image_one_to_one.name}
+</f:if>
 <f:if condition="{data.pass}">
     pass: {data.pass}
 </f:if>

--- a/Tests/Functional/Frontend/ContentBlockFrontendRenderingTest.php
+++ b/Tests/Functional/Frontend/ContentBlockFrontendRenderingTest.php
@@ -149,6 +149,7 @@ final class ContentBlockFrontendRenderingTest extends FunctionalTestCase
         $html = (string)$response->getBody();
 
         self::assertStringContainsString('image:kasper-skarhoj1.jpg', $html);
+        self::assertStringContainsString('image_one_to_one:kasper-skarhoj1.jpg', $html);
     }
 
     #[Test]

--- a/Tests/Functional/Frontend/Fixtures/DataSet/file_references.csv
+++ b/Tests/Functional/Frontend/Fixtures/DataSet/file_references.csv
@@ -1,10 +1,11 @@
 "sys_file_reference"
 ,"uid","pid","uid_local","uid_foreign","tablenames","fieldname","sorting_foreign","t3ver_wsid","t3ver_state","t3ver_stage","t3ver_oid"
 ,1,1,1,1,"tt_content","image",1,0,0,0,0
+,2,1,1,1,"tt_content","typo3tests_contentelementb_image_one_to_one",1,0,0,0,0
 "sys_file",,,,,,,,,,,,,,,,,,,
 ,"uid","pid","type","storage","identifier","extension","mime_type","name","sha1","size","creation_date","modification_date","missing","metadata","identifier_hash","folder_hash","last_indexed"
 ,1,0,2,1,"/kasper-skarhoj1.jpg","jpg","image/jpeg","kasper-skarhoj1.jpg","05d8c6dda534a0b9e7023c3031e60e4b49c3da40",39037,1677330452,1658395918,0,0,"98576a90d58d51fcfe91c41f4c571fd600e1190e","42099b4af021e53fd8fd4e056c2568d7c2e3ffa8",0
 "tt_content"
-,"uid","pid","t3ver_oid","t3ver_wsid","typo3tests_contentelementb_collection_one_to_one","CType"
-,1,1,0,0,2,"typo3tests_contentelementb"
-,2,1,1,1,2,"typo3tests_contentelementb"
+,"uid","pid","t3ver_oid","t3ver_wsid","typo3tests_contentelementb_collection_one_to_one","typo3tests_contentelementb_image_one_to_one","CType"
+,1,1,0,0,1,1,"typo3tests_contentelementb"
+,2,1,1,1,0,0,"typo3tests_contentelementb"

--- a/Tests/Functional/Frontend/Fixtures/DataSet/file_references.csv
+++ b/Tests/Functional/Frontend/Fixtures/DataSet/file_references.csv
@@ -7,5 +7,5 @@
 ,1,0,2,1,"/kasper-skarhoj1.jpg","jpg","image/jpeg","kasper-skarhoj1.jpg","05d8c6dda534a0b9e7023c3031e60e4b49c3da40",39037,1677330452,1658395918,0,0,"98576a90d58d51fcfe91c41f4c571fd600e1190e","42099b4af021e53fd8fd4e056c2568d7c2e3ffa8",0
 "tt_content"
 ,"uid","pid","t3ver_oid","t3ver_wsid","typo3tests_contentelementb_collection_one_to_one","typo3tests_contentelementb_image_one_to_one","CType"
-,1,1,0,0,1,1,"typo3tests_contentelementb"
-,2,1,1,1,0,0,"typo3tests_contentelementb"
+,1,1,0,0,2,1,"typo3tests_contentelementb"
+,2,1,1,1,2,0,"typo3tests_contentelementb"


### PR DESCRIPTION
With version 1.3.12 of Content Blocks, we received the following error for fields of type “File” and the relationship “oneToOne”.

```
(1/1) TypeError
TYPO3\CMS\ContentBlocks\DataProcessing\ContentBlockDataDecorator::handleRelation(): Argument #1 ($resolvedField) must be of type TYPO3\CMS\Core\Domain\RecordInterface|TYPO3\CMS\Core\Collection\LazyRecordCollection|TYPO3\CMS\Core\Resource\Collection\LazyFileReferenceCollection|null, TYPO3\CMS\Core\Resource\FileReference given, called in /var/www/html/vendor/friendsoftypo3/content-blocks/Classes/DataProcessing/ContentBlockDataDecorator.php on line 129
```

This pull request improve function test with relationship "oneToOne" and fixes the error.