### PR TITLE
[BUGFIX] Adjust ext_emconf description for composer title in v14

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -2,7 +2,7 @@
 
 $EM_CONF[$_EXTKEY] = [
     'title' => 'TYPO3 CMS Content Blocks',
-    'description' => 'TYPO3 CMS Content Blocks - Content Types API | Define reusable components via YAML',
+    'description' => 'Content Types API | Define reusable components via YAML',
     'category' => 'be',
     'author' => 'TYPO3 Content Types Team',
     'author_email' => 'typo3cms@typo3.org',


### PR DESCRIPTION
Since TYPO3 v14, the extension title is populated from `composer.json`. The Extension Manager validates that the composer description equals `$emConf['title'] . ' - ' . $emConf['description']`.

The current `ext_emconf.php` duplicated the extension name in the description, causing `EXTENSION_TITLE_MISSING` to be reported.

This change removes the redundant prefix and restores consistency with `composer.json` handling.

References: [Breaking: #108304 - Populate extension title from composer.json](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Breaking-108304-PopulateExtensionTitleFromComposerJson.html)