### PR TITLE
[BUGFIX] Re-enable BE Previews for Page Types #462

### DIFF
--- a/Classes/Backend/Preview/PageLayout.php
+++ b/Classes/Backend/Preview/PageLayout.php
@@ -56,7 +56,8 @@ readonly class PageLayout
         $request = $event->getRequest();
         /** @var ModuleData $moduleData */
         $moduleData = $request->getAttribute('moduleData');
-        if ((int)$moduleData->get('viewMode') !== PageViewMode::LayoutView->value) {
+        $viewMode = PageViewMode::LayoutView::tryFrom((int)$moduleData->get('viewMode'));
+        if ($viewMode !== PageViewMode::LayoutView) {
             return;
         }
         $pageTypeTable = 'pages';

--- a/Classes/Backend/Preview/PageLayout.php
+++ b/Classes/Backend/Preview/PageLayout.php
@@ -21,6 +21,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Controller\Event\ModifyPageLayoutContentEvent;
 use TYPO3\CMS\Backend\Module\ModuleData;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Backend\View\PageViewMode;
 use TYPO3\CMS\ContentBlocks\DataProcessing\ContentBlockDataDecorator;
 use TYPO3\CMS\ContentBlocks\DataProcessing\ContentTypeResolver;
 use TYPO3\CMS\ContentBlocks\Definition\ContentType\ContentTypeInterface;
@@ -55,8 +56,7 @@ readonly class PageLayout
         $request = $event->getRequest();
         /** @var ModuleData $moduleData */
         $moduleData = $request->getAttribute('moduleData');
-        $function = (int)($moduleData->get('function') ?? 0);
-        if ($function !== 1) {
+        if ((int)$moduleData->get('viewMode') !== PageViewMode::LayoutView->value) {
             return;
         }
         $pageTypeTable = 'pages';


### PR DESCRIPTION
With [TYPO3 00652c9](https://github.com/TYPO3/typo3/commit/00652c9) `ModuleData->function` was renamed to `ModuleData->viewMode`.

Resolves: #462