### PR TITLE
[TASK] Run CI containers with docker

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,14 @@
 name: Tests
+
+# Every "runTests.sh" call below passes "-b docker". The script prefers podman
+# whenever it is present and only falls back to docker, which is the right
+# default for it -- but GitHub hosted runners ship both, and their podman/crun
+# combination aborts the first container start of a job with "OCI runtime error:
+# crun: unknown version specified" (exit code 126). It is intermittent and hits
+# any job. Selecting docker here avoids crun entirely and leaves the script
+# default and local runs untouched. Drop the flag once GitHub stops producing
+# the mismatch.
+
 on:
   push:
     branches:
@@ -41,10 +51,10 @@ jobs:
         run: composer update --no-progress
 
       - name: PHP CS Fixer
-        run: Build/Scripts/runTests.sh -p 8.2 -s cgl -n
+        run: Build/Scripts/runTests.sh -b docker -p 8.2 -s cgl -n
 
       - name: PHP CS Fixer Header
-        run: Build/Scripts/runTests.sh -p 8.2 -s cglHeader -n
+        run: Build/Scripts/runTests.sh -b docker -p 8.2 -s cglHeader -n
 
       - name: Content Blocks Lint
         run: .Build/bin/typo3 content-blocks:lint
@@ -79,7 +89,7 @@ jobs:
         run: composer update --prefer-dist --prefer-stable --no-progress
 
       - name: Unit
-        run: Build/Scripts/runTests.sh -s unit -p ${{ matrix.php }}
+        run: Build/Scripts/runTests.sh -b docker -s unit -p ${{ matrix.php }}
 
   functional_tests:
     name: Functional Tests TYPO3 v14 PHP ${{ matrix.php }}
@@ -111,7 +121,7 @@ jobs:
         run: composer update --prefer-stable --no-progress
 
       - name: Functional
-        run: Build/Scripts/runTests.sh -s functional -d sqlite -p ${{ matrix.php }}
+        run: Build/Scripts/runTests.sh -b docker -s functional -d sqlite -p ${{ matrix.php }}
 
   PHPStan:
     name: PHPStan TYPO3 v14 PHP 8.5

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1104,7 +1104,14 @@ case ${TEST_SUITE} in
             sqlite)
                 # create sqlite tmpfs mount typo3temp/var/tests/functional-sqlite-dbs/ to avoid permission issues
                 mkdir -p "${CORE_ROOT}/typo3temp/var/tests/functional-sqlite-dbs/"
-                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${CORE_ROOT}/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid"
+                # "mode=1777" is required for docker and harmless for podman: docker runs
+                # the container as "--user $HOST_UID" with group 0, while the tmpfs inherits
+                # the mode of its host mountpoint -- 0755 and owned by root at the umask a
+                # runner uses. The test databases cannot be created then and every test fails
+                # with "unable to open database file". Rootless podman is root inside its
+                # user namespace and passes no "--user", which is why this only shows with
+                # docker.
+                CONTAINERPARAMS="-e typo3DatabaseDriver=pdo_sqlite --tmpfs ${CORE_ROOT}/typo3temp/var/tests/functional-sqlite-dbs/:rw,noexec,nosuid,mode=1777"
                 ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name functional-${SUFFIX} ${XDEBUG_MODE} -e XDEBUG_CONFIG="${XDEBUG_CONFIG}" ${CONTAINERPARAMS} ${IMAGE_PHP} "${COMMAND[@]}"
                 SUITE_EXIT_CODE=$?
                 ;;


### PR DESCRIPTION
Fixes the scheduled `Tests` pipeline failures described in #544.

## Why

GitHub hosted runners ship both podman and docker. Their podman/crun combination
intermittently aborts the **first container start of a job**:

```
Trying to pull ghcr.io/typo3/core-testing-php84:1.8...
Error: OCI runtime error: crun: unknown version specified
Container runtime: podman
##[error]Process completed with exit code 126.
```

Scheduled run [30515790010](https://github.com/FriendsOfTYPO3/content-blocks/actions/runs/30515790010)
(2026-07-30) failed that way in `Unit Tests TYPO3 v14 PHP 8.4`,
`Functional Tests TYPO3 v14 PHP 8.3` and `Functional Tests TYPO3 v14 PHP 8.4`,
with 11 occurrences. Because it hits the first container start, which jobs fail
varies per run and a rerun on another host usually clears it.

## The change

`Build/Scripts/runTests.sh` prefers podman whenever it is present and only falls
back to docker. That default is correct for the script — podman-only machines are
exactly what it is built for — so it is kept unchanged. The hosted runners are the
single place these workflows meet the broken combination, so the override belongs
in the workflow: all four `runTests.sh` calls in `.github/workflows/tests.yaml`
now pass `-b docker`, with the reasoning in the workflow header so the flag can be
dropped again once GitHub stops producing the mismatch.

## Second, follow-up fix in the same change

Selecting docker exposes a defect that podman masks. docker runs the container as
`--user $HOST_UID` with group 0, while the functional sqlite `--tmpfs` inherits the
mode of its host mountpoint — `0755` owned by root at the umask a runner uses. No
test database can be created then, and every functional sqlite test fails with
`unable to open database file`. Rootless podman is root inside its user namespace
and passes no `--user`, which is why this never showed before.

That tmpfs is therefore mounted with `mode=1777`: docker needs it, podman does not
mind, and it stays correct regardless of which runtime is selected. Only the sqlite
mount is touched — the mariadb/mysql/postgres tmpfs mounts get no `--user` and run
as root, so they are unaffected.

## Notes

* No workflow structure changes — only the backend flag and the header comment.
* Verified locally: `bash -n Build/Scripts/runTests.sh` passes, the workflow still
  parses, no call carries two `-b` flags.
* Against `main` only, so you can decide about backports yourself.
* The same two changes are in use across a number of TYPO3 extension repositories
  that share this `runTests.sh` approach, and originate from
  fgtclb/academic-extensions#367.
* Unrelated to this pull request: the scheduled failures on 2026-07-27/28/29 had a
  different cause (a `typo3/coding-standards 0.8.x-dev` constraint that no longer
  resolves) — see #544 for the detail.
